### PR TITLE
Fix duplicate on_ready event

### DIFF
--- a/main.py
+++ b/main.py
@@ -158,12 +158,13 @@ async def start_reporting():
             print("✅ XML получен")
 
         lines = parse_vehicles(xml_data)
-        lines.insert(0, "**──────────────────────────────────────── ТЕХНИКА НУЖДАЮЩАЯСЯ В ОБСЛУЖИВАНИИ ────────────────────────────────────────**")
         if not lines:
             print("ℹ️ Нет техники для обслуживания")
             await channel.send("ℹ️ Нет техники для обслуживания")
             await asyncio.sleep(30)
             continue
+
+        lines.insert(0, "**──────────────────────────────────────── ТЕХНИКА НУЖДАЮЩАЯСЯ В ОБСЛУЖИВАНИИ ────────────────────────────────────────**")
 
         for block in split_messages(lines):
             try:
@@ -173,10 +174,4 @@ async def start_reporting():
                 print(f"Ошибка отправки: {e}")
 
         await asyncio.sleep(600)
-
-@client.event
-async def on_ready():
-    print(f"✅ Logged in as {client.user}")
-    await start_reporting()
-
 client.run(TOKEN)


### PR DESCRIPTION
## Summary
- remove second definition of `on_ready` to prevent event override
- avoid sending header when there are no vehicles

## Testing
- `python3 -m py_compile main.py vehicle_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_685c7dc97204832bafecf15b9e0f0c36