### PR TITLE
Remove styling from output and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# fs25-discord-bot
+fs25-discord-bot
 
 Отображение техники которая нуждается в обслуживании
 ( damage: <5% , dirt: <5%, fuel: >80% )
 
-## Загрузчик FTP-файлов
+Загрузчик FTP-файлов
 
-Скрипт `ftp_upload.py` позволяет загружать произвольные файлы на FTP-сервер.
+Скрипт ftp_upload.py позволяет загружать произвольные файлы на FTP-сервер.
 Параметры подключения можно передавать через аргументы командной строки
-или переменные окружения `FTP_HOST`, `FTP_PORT`, `FTP_USER`, `FTP_PASS`.
+или переменные окружения FTP_HOST, FTP_PORT, FTP_USER, FTP_PASS.
 
 Пример запуска:
 
-```bash
 python ftp_upload.py local.zip /remote/path/remote.zip --host example.com --user user --password pass
-```
 

--- a/main.py
+++ b/main.py
@@ -108,10 +108,8 @@ def format_output(groups):
     )
     result = []
     for cat, items in sorted_items:
-        icon = get_icon_by_class(cat)
-        block = [f"{icon} {cat}:", "```"]
+        block = [f"{cat}:"]
         block.extend(items)
-        block.append("```")
         result.append("\n".join(block))
     return result
 
@@ -179,14 +177,11 @@ async def start_reporting():
 
         if critical:
             crit_block = [
-                "❗ Техника в критическом состоянии:",
-                "```",
+                "Техника в критическом состоянии:",
             ]
             crit_block.extend(critical)
-            crit_block.append("```")
             output_lines.append("\n".join(crit_block))
 
-        lines.insert(0, "**──────────────────────────────────────── ТЕХНИКА НУЖДАЮЩАЯСЯ В ОБСЛУЖИВАНИИ ────────────────────────────────────────**")
 
         output_lines.extend(lines)
 


### PR DESCRIPTION
## Summary
- strip Markdown formatting from README
- send plain text messages without bold or code blocks

## Testing
- `python -m py_compile main.py ftp_upload.py vehicle_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb57528b4832baac6240e612ead52