### PR TITLE
Adjust fuel display logic

### DIFF
--- a/classify_vehicles.py
+++ b/classify_vehicles.py
@@ -13,15 +13,23 @@ def classify_vehicles(vehicles: List[Dict]) -> str:
         damage = float(v.get("damage", 0))
         fuel = float(v.get("fuel", 0))
         capacity = float(v.get("fuel_capacity", 0)) or 1
+        uses_fuel = v.get("uses_fuel", capacity > 0)
 
         if damage > 50 and fuel < 0.4 * capacity:
-            damaged.append(f"• {name} — поврежд. {int(damage)}%, топливо: {int(fuel)}")
+            msg = f"• {name} — поврежд. {int(damage)}%"
+            if uses_fuel:
+                msg += f", топливо: {int(fuel)}"
+            damaged.append(msg)
         elif dirt > 50:
-            dirty.append(f"• {name} — грязь: {int(dirt)}%")
+            msg = f"• {name} — грязь: {int(dirt)}%"
+            if uses_fuel and fuel < 0.8 * capacity:
+                msg += f", топливо: {int(fuel)}"
+            dirty.append(msg)
         elif damage > 5 or dirt > 5 or fuel < 0.8 * capacity:
-            other.append(
-                f"• {name} — грязь: {int(dirt)}%, поврежд.: {int(damage)}%, топливо: {int(fuel)}"
-            )
+            msg = f"• {name} — грязь: {int(dirt)}%, поврежд.: {int(damage)}%"
+            if uses_fuel and fuel < 0.8 * capacity:
+                msg += f", топливо: {int(fuel)}"
+            other.append(msg)
 
     lines = []
 

--- a/main.py
+++ b/main.py
@@ -75,6 +75,7 @@ def collect_vehicles(xml_data):
             dirt, damage, fuel = extract_vehicle_info(vehicle)
             info = get_info_by_key(filename)
             max_fuel = info.get("fuel_capacity") or 0
+            uses_fuel = info.get("uses_fuel", bool(max_fuel))
 
             if damage <= 0.05 and dirt <= 0.05 and (not max_fuel or fuel >= 0.8 * max_fuel):
                 continue
@@ -86,6 +87,7 @@ def collect_vehicles(xml_data):
                     "damage": damage * 100,
                     "fuel": fuel,
                     "fuel_capacity": max_fuel,
+                    "uses_fuel": uses_fuel,
                 }
             )
     except Exception as e:


### PR DESCRIPTION
## Summary
- track `uses_fuel` in collected vehicle info
- hide fuel for machines that don't use fuel
- only display fuel in most categories when below 80%

## Testing
- `python -m py_compile classify_vehicles.py main.py vehicle_filter.py ftp_upload.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc3e42710832b8a76a009e0cc1835