### PR TITLE
Refactor vehicle utilities

### DIFF
--- a/classify_vehicles.py
+++ b/classify_vehicles.py
@@ -1,19 +1,21 @@
-from typing import List, Dict
+from typing import Iterable
+
+from models import Vehicle
 
 
-def classify_vehicles(vehicles: List[Dict]) -> str:
-    """Return formatted markdown with vehicle statuses."""
-    damaged = []
-    dirty = []
-    other = []
+def classify_vehicles(vehicles: Iterable[Vehicle]) -> str:
+    """Return formatted markdown describing vehicle statuses."""
+    damaged: list[str] = []
+    dirty: list[str] = []
+    other: list[str] = []
 
     for v in vehicles:
-        name = v.get("name", "?")
-        dirt = float(v.get("dirt", 0))
-        damage = float(v.get("damage", 0))
-        fuel = float(v.get("fuel", 0))
-        capacity = float(v.get("fuel_capacity", 0)) or 1
-        uses_fuel = v.get("uses_fuel", capacity > 0)
+        name = v.name
+        dirt = float(v.dirt)
+        damage = float(v.damage)
+        fuel = float(v.fuel)
+        capacity = float(v.fuel_capacity) or 1
+        uses_fuel = v.uses_fuel
 
         is_damaged = damage > 50 or (uses_fuel and fuel < 0.4 * capacity)
         is_dirty = dirt > 50
@@ -65,24 +67,3 @@ def classify_vehicles(vehicles: List[Dict]) -> str:
 
     return "\n".join(lines)
 
-
-if __name__ == "__main__":
-    example = [
-        {
-            "name": "Техника 1",
-            "dirt": 60,
-            "damage": 70,
-            "fuel": 10,
-            "fuel_capacity": 100,
-        },
-        {
-            "name": "Техника 2",
-            "dirt": 55,
-            "damage": 10,
-            "fuel": 80,
-            "fuel_capacity": 120,
-        },
-        {"name": "Техника 3", "dirt": 10, "damage": 0, "fuel": 0, "fuel_capacity": 0},
-    ]
-    markdown = classify_vehicles(example)
-    print(markdown)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Vehicle:
+    """Represent the status of a vehicle."""
+
+    name: str
+    dirt: float
+    damage: float
+    fuel: float
+    fuel_capacity: float
+    uses_fuel: bool

--- a/vehicle_filter.py
+++ b/vehicle_filter.py
@@ -2,39 +2,18 @@ import json
 
 # Load vehicle information from the filtered list shipped with the bot
 with open("filtered_vehicles.json", "r", encoding="utf-8") as f:
-    data = json.load(f)
+    VEHICLE_DATA = json.load(f)
 
 # Map XML file key to the corresponding info dictionary
-vehicle_map = {}
-for entry in data:
+vehicle_map: dict[str, dict] = {}
+for entry in VEHICLE_DATA:
     key = entry.get("nameXML") or entry.get("xml_key")
     if key:
         vehicle_map[key] = entry
 
-# Build a mapping from class name to icon for quick lookup (may be empty)
-class_icon_map = {
-    entry["class"]: entry.get("icon") for entry in data if entry.get("class")
-}
-
-CATEGORY_ORDER = [
-    "Трактор",
-    "Комбайн",
-    "Жатка",
-    "Культиватор",
-    "Сеялка",
-    "Опрыскиватель",
-    "Тюковый пресс",
-    "Обмотчик тюков",
-    "Погрузчик",
-    "Прицеп",
-    "Силосный погрузчик",
-    "Грузовик",
-    "Оборудование",
-    "Неизвестная техника",
-]
 
 
-def get_info_by_key(xml_key):
+def get_info_by_key(xml_key: str) -> dict:
     """Return info for the given XML key or sensible defaults."""
     return vehicle_map.get(
         xml_key,
@@ -45,8 +24,3 @@ def get_info_by_key(xml_key):
             "fuel_capacity": None,
         },
     )
-
-
-def get_icon_by_class(class_name):
-    """Return icon for the given class name."""
-    return class_icon_map.get(class_name, "🛠️")


### PR DESCRIPTION
## Summary
- add a simple `Vehicle` dataclass
- type-hint and refactor `classify_vehicles` to accept dataclass objects
- return dataclass objects from `collect_vehicles`
- remove unused helpers from `vehicle_filter`

## Testing
- `python -m compileall -q && echo done`

------
https://chatgpt.com/codex/tasks/task_e_685cce0111cc832b9a35385575d3d974