### PR TITLE
Fix missing main entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ fs25-discord-bot
 Запуск бота:
 
 ```bash
-python -m bot.main
+python main.py
 ```
 
 Загрузка файлов на FTP сервер:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from bot.main import client
+from config import config
+
+if __name__ == "__main__":
+    client.run(config.DISCORD_TOKEN)


### PR DESCRIPTION
## Summary
- add a simple `main.py` entrypoint to run the bot
- update README to use `python main.py`

## Testing
- `python -m py_compile main.py bot/main.py bot/discord_ui.py ftp/client.py ftp/upload.py modules/vehicles.py utils/helpers.py config/config.py`


------
https://chatgpt.com/codex/tasks/task_e_685dc1c9520c832b922a3a3cb1ed6372