### PR TITLE
Fix BytesIO FTP download bug

### DIFF
--- a/ftp/client.py
+++ b/ftp/client.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 from typing import Optional
+import tempfile
 
 import aioftp
 
@@ -15,9 +15,15 @@ async def fetch_file(path: str) -> Optional[bytes]:
             config.FTP_USER,
             config.FTP_PASS,
         ) as ftp:
-            buffer = BytesIO()
-            await ftp.download(path, buffer)
-            return buffer.getvalue()
+            # ``aioftp.Client.download`` expects a filesystem path. Previously we
+            # passed a ``BytesIO`` buffer which caused ``open`` to raise an
+            # exception like ``expected str, bytes or os.PathLike object, not
+            # BytesIO``. To avoid this error we download the file to a temporary
+            # location and then read the contents back into memory.
+            with tempfile.NamedTemporaryFile() as tmp:
+                await ftp.download(path, tmp.name)
+                tmp.seek(0)
+                return tmp.read()
     except Exception as exc:
         print(f"FTP error: {exc}")
         return None


### PR DESCRIPTION
## Summary
- fix `fetch_file` to download to a temporary file instead of using `BytesIO`

## Testing
- `black . --check`

------
https://chatgpt.com/codex/tasks/task_e_685dc3f224b8832b942e4902a165697e