### PR TITLE
Improve env var handling

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,13 +1,20 @@
 import os
 
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
-DISCORD_CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID", "0"))
 
-FTP_HOST = os.getenv("FTP_HOST", "")
-FTP_PORT = int(os.getenv("FTP_PORT", "21"))
-FTP_USER = os.getenv("FTP_USER", "")
-FTP_PASS = os.getenv("FTP_PASS", "")
-FTP_PATH = os.getenv("FTP_PATH", "")
+def _get_env(name: str, default: str = "") -> str:
+    """Return an environment variable without surrounding quotes."""
+    value = os.getenv(name, default)
+    return value.strip().strip('"').strip("'")
+
+
+DISCORD_TOKEN = _get_env("DISCORD_TOKEN")
+DISCORD_CHANNEL_ID = int(_get_env("DISCORD_CHANNEL_ID", "0"))
+
+FTP_HOST = _get_env("FTP_HOST")
+FTP_PORT = int(_get_env("FTP_PORT", "21"))
+FTP_USER = _get_env("FTP_USER")
+FTP_PASS = _get_env("FTP_PASS")
+FTP_PATH = _get_env("FTP_PATH")
 
 FARM_ID = os.getenv("FARM_ID", "1")
 


### PR DESCRIPTION
## Summary
- sanitize env vars by stripping surrounding quotes before using them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc6c8ece8832bba7e7e3999a7fa16