### PR TITLE
Improve FTP debug output

### DIFF
--- a/ftp/client.py
+++ b/ftp/client.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import tempfile
+import traceback
 
 import aioftp
 
@@ -8,6 +9,12 @@ from config import config
 
 async def fetch_file(path: str) -> Optional[bytes]:
     """Download a file from the configured FTP server."""
+    print(
+        "Connecting to FTP",
+        f"host={config.FTP_HOST}",
+        f"port={config.FTP_PORT}",
+        f"user={config.FTP_USER}",
+    )
     try:
         async with aioftp.Client.context(
             config.FTP_HOST,
@@ -15,6 +22,7 @@ async def fetch_file(path: str) -> Optional[bytes]:
             config.FTP_USER,
             config.FTP_PASS,
         ) as ftp:
+            print(f"Connected. Downloading {path}")
             # ``aioftp.Client.download`` expects a filesystem path. Previously we
             # passed a ``BytesIO`` buffer which caused ``open`` to raise an
             # exception like ``expected str, bytes or os.PathLike object, not
@@ -22,8 +30,12 @@ async def fetch_file(path: str) -> Optional[bytes]:
             # location and then read the contents back into memory.
             with tempfile.NamedTemporaryFile() as tmp:
                 await ftp.download(path, tmp.name)
+                print(f"Downloaded to {tmp.name}")
                 tmp.seek(0)
-                return tmp.read()
+                data = tmp.read()
+                print(f"Read {len(data)} bytes")
+                return data
     except Exception as exc:
         print(f"FTP error: {exc}")
+        traceback.print_exc()
         return None


### PR DESCRIPTION
## Summary
- add more detailed debug logging in ftp client

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685dd1015048832b983131d06f7af3a6