### PR TITLE
Add traceback when FTP download fails

### DIFF
--- a/ftp/client.py
+++ b/ftp/client.py
@@ -2,6 +2,7 @@ from typing import Optional
 import tempfile
 
 import aioftp
+import traceback
 
 from config import config
 
@@ -26,4 +27,5 @@ async def fetch_file(path: str) -> Optional[bytes]:
                 return tmp.read()
     except Exception as exc:
         print(f"FTP error: {exc}")
+        traceback.print_exc()
         return None


### PR DESCRIPTION
## Summary
- improve FTP error diagnostics by showing tracebacks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dd63d4898832ba750c976ca0ecea7