### PR TITLE
Add traceback when FTP download fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ fs25-discord-bot
 При указании переменных окружения значения не нужно брать в кавычки. Пример конфигурации:
 
 ```bash
+DISCORD_TOKEN=your_token
+DISCORD_CHANNEL_ID=123456789012345678
+FTP_HOST=ftp.example.com
+FTP_PORT=21
+FTP_USER=username
+FTP_PASS=secret
+FTP_PATH=/profile/savegame1/vehicles.xml
+```
 
 Если значение всё же содержит кавычки, бот удалит их автоматически при загрузке настроек.
 

--- a/ftp/client.py
+++ b/ftp/client.py
@@ -2,6 +2,7 @@ from typing import Optional
 import tempfile
 
 import aioftp
+import traceback
 
 from config import config
 
@@ -15,15 +16,13 @@ async def fetch_file(path: str) -> Optional[bytes]:
             config.FTP_USER,
             config.FTP_PASS,
         ) as ftp:
-            # ``aioftp.Client.download`` expects a filesystem path. Previously we
-            # passed a ``BytesIO`` buffer which caused ``open`` to raise an
-            # exception like ``expected str, bytes or os.PathLike object, not
-            # BytesIO``. To avoid this error we download the file to a temporary
-            # location and then read the contents back into memory.
+            # Download the file to a temporary location.
             with tempfile.NamedTemporaryFile() as tmp:
-                await ftp.download(path, tmp.name)
+                # ``write_into=True`` avoids treating ``tmp.name`` as a directory.
+                await ftp.download(path, tmp.name, write_into=True)
                 tmp.seek(0)
                 return tmp.read()
     except Exception as exc:
         print(f"FTP error: {exc}")
+        traceback.print_exc()
         return None

--- a/ftp/upload.py
+++ b/ftp/upload.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import os
 
 import aioftp
 from config import config


### PR DESCRIPTION
## Summary
- improve FTP error diagnostics by showing tracebacks
- download to temporary file correctly when using aioftp
- clean up comments and imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685dd63d4898832ba750c976ca0ecea7