### PR TITLE
Add fields status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ FTP_PORT=21
 FTP_USER=username
 FTP_PASS=secret
 FTP_PATH=/profile/savegame1/vehicles.xml
+FTP_PATH_FIELDS=/profile/savegame1/fields.xml
 ```
 
 Если значение всё же содержит кавычки, бот удалит их автоматически при загрузке настроек.

--- a/bot/main.py
+++ b/bot/main.py
@@ -4,18 +4,33 @@ import discord
 from config import config
 from ftp import client as ftp_client
 from modules.vehicles import parse_vehicles, classify_vehicles
+from modules.fields import parse_field_statuses
 from utils.helpers import split_messages
 from .discord_ui import create_report_embed
 
 intents = discord.Intents.default()
 client = discord.Client(intents=intents)
+tree = discord.app_commands.CommandTree(client)
 
 _last_messages: list[discord.Message] = []
+
+
+@tree.command(name="поля", description="Показать статус всех полей")
+async def show_fields(interaction: discord.Interaction):
+    xml_bytes = await ftp_client.fetch_fields_file()
+    statuses = parse_field_statuses(xml_bytes)
+
+    embed = discord.Embed(title="🗺️ Статус полей", color=0x2ecc71)
+    for line in statuses:
+        embed.add_field(name="\u200b", value=line, inline=False)
+
+    await interaction.response.send_message(embed=embed)
 
 
 @client.event
 async def on_ready():
     print(f"Бот запущен как {client.user}")
+    await tree.sync()
     await start_reporting()
 
 

--- a/config/config.py
+++ b/config/config.py
@@ -21,6 +21,7 @@ FTP_PORT = int(_get_env("FTP_PORT", "21"))
 FTP_USER = _get_env("FTP_USER")
 FTP_PASS = _get_env("FTP_PASS")
 FTP_PATH = _get_env("FTP_PATH")
+FTP_PATH_FIELDS = _get_env("FTP_PATH_FIELDS")
 
 FARM_ID = os.getenv("FARM_ID", "1")
 

--- a/ftp/client.py
+++ b/ftp/client.py
@@ -26,3 +26,9 @@ async def fetch_file(path: str) -> Optional[bytes]:
         print(f"FTP error ({type(exc).__name__}): {exc}")
         traceback.print_exc()
         return None
+
+
+async def fetch_fields_file() -> bytes:
+    """Download fields.xml via FTP and return as bytes."""
+    data = await fetch_file(config.FTP_PATH_FIELDS)
+    return data or b""

--- a/modules/fields.py
+++ b/modules/fields.py
@@ -1,5 +1,42 @@
 """Placeholder for field analysis logic."""
 
+import xml.etree.ElementTree as ET
+
+
+def parse_field_statuses(xml_bytes: bytes) -> list[str]:
+    """Parse fields.xml and return formatted status lines."""
+    result: list[str] = []
+    try:
+        root = ET.fromstring(xml_bytes)
+        for elem in root.findall(".//field"):
+            num = elem.get("number") or elem.get("id") or "?"
+            fruit = (elem.get("fruitType") or "").upper()
+            growth = int(elem.get("growthState", "0"))
+            weeds = int(elem.get("weedState", "0"))
+            lime = float(elem.get("limeLevel", "0"))
+            plow = float(elem.get("plowLevel", "0"))
+            spray = float(elem.get("sprayLevel", "0"))
+
+            if not fruit or fruit == "NONE":
+                result.append(f"#{num} 🟫 Пустое | можно сеять")
+                continue
+
+            parts = [f"#{num} 🌾 {fruit}"]
+            if growth >= 7:
+                parts.append("🧺 Урожай готов")
+            else:
+                parts.append(f"стадия: {growth}/7")
+
+            parts.append(f"💧 удобрение: {int(spray * 100)}%")
+            parts.append(f"🌱 сорняки: {'✅' if weeds else '❌'}")
+            parts.append(f"🧂 известь: {'✅' if lime else '❌'}")
+            parts.append(f"🔨 вспашка: {'✅' if plow else '❌'}")
+
+            result.append(" | ".join(parts))
+    except Exception as exc:
+        print(f"XML parse error: {exc}")
+    return result
+
 
 def analyze_fields(data: bytes) -> str:
     return "Анализ полей пока не реализован"


### PR DESCRIPTION
## Summary
- support FTP path for `fields.xml`
- download `fields.xml` from FTP
- parse field information and format status output
- add `/поля` slash command to show field statuses
- document `FTP_PATH_FIELDS` environment variable

## Testing
- `python -m py_compile bot/main.py ftp/client.py modules/fields.py config/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685decddec74832bb9e420c811a7e062