### PR TITLE
Code cleanup and optimization

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -22,10 +22,10 @@ async def show_fields(ctx: discord.ApplicationContext):
     xml_bytes = await ftp_client.fetch_fields_file()
     statuses = parse_field_statuses(xml_bytes)
 
-    chunks = [statuses[i:i+25] for i in range(0, len(statuses), 25)]
+    chunks = [statuses[i : i + 25] for i in range(0, len(statuses), 25)]
 
     for chunk in chunks:
-        embed = discord.Embed(title="🗺️ Статус полей", color=0x2ecc71)
+        embed = discord.Embed(title="🗺️ Статус полей", color=0x2ECC71)
         for line in chunk:
             embed.add_field(name="​", value=line, inline=False)
         await ctx.send(embed=embed)

--- a/bot/tasks/update_fields_status.py
+++ b/bot/tasks/update_fields_status.py
@@ -3,6 +3,7 @@ from modules.fields import parse_field_statuses
 from config import config
 from utils.message_tracker import get_id, set_id
 
+
 async def update_fields_status(client, ftp_client):
     """
     Обновляет или создаёт сообщение со статусом полей
@@ -17,7 +18,7 @@ async def update_fields_status(client, ftp_client):
 
         # Берём только первую страницу (до 25 строк)
         chunk = statuses[:25]
-        embed = discord.Embed(title="🗺️ Статус полей", color=0x27ae60)
+        embed = discord.Embed(title="🗺️ Статус полей", color=0x27AE60)
         for line in chunk:
             embed.add_field(name="\u200b", value=line, inline=False)
 
@@ -42,4 +43,3 @@ async def update_fields_status(client, ftp_client):
 
     except Exception as e:
         print(f"[Поля] Ошибка обновления: {e}")
-

--- a/config/config.py
+++ b/config/config.py
@@ -4,11 +4,7 @@ import os
 def _get_env(name: str, default: str = "") -> str:
     """Return an environment variable without surrounding quotes."""
     value = os.getenv(name, default).strip()
-    if (
-        len(value) >= 2
-        and value[0] == value[-1]
-        and value[0] in {'"', "'"}
-    ):
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
         return value[1:-1]
     return value
 

--- a/modules/fields.py
+++ b/modules/fields.py
@@ -1,28 +1,27 @@
-import xml.etree.ElementTree as ET
-from typing import List
 import json
+import xml.etree.ElementTree as ET
+from typing import Dict, List
 
 # Загрузка JSON с каталогом культур
 with open("data/crops_catalog.json", "r", encoding="utf-8") as f:
-    crops_catalog = json.load(f)
+    _CATALOG: Dict[str, dict] = {c["nameXML"]: c for c in json.load(f)}
 
-def get_crop_name(code):
-    for crop in crops_catalog:
-        if crop["nameXML"] == code:
-            return crop["name"]
-    return "UNKNOWN"
 
-def get_crop_emoji(code):
-    for crop in crops_catalog:
-        if crop["nameXML"] == code:
-            return crop["emoji"]
-    return "❓"
+def _lookup(code: str) -> dict:
+    return _CATALOG.get(code, {})
 
-def get_crop_growth_max(code):
-    for crop in crops_catalog:
-        if crop["nameXML"] == code:
-            return crop["growth_stages"]
-    return 0
+
+def get_crop_name(code: str) -> str:
+    return _lookup(code).get("name", "UNKNOWN")
+
+
+def get_crop_emoji(code: str) -> str:
+    return _lookup(code).get("emoji", "❓")
+
+
+def get_crop_growth_max(code: str) -> int:
+    return int(_lookup(code).get("growth_stages", 0))
+
 
 # Основной разбор статуса полей
 def parse_field_statuses(xml_bytes: bytes) -> List[str]:

--- a/utils/message_tracker.py
+++ b/utils/message_tracker.py
@@ -4,19 +4,23 @@ from pathlib import Path
 DATA_FILE = Path("data/messages.json")
 DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
 
+
 def load_ids():
     if DATA_FILE.exists():
         with open(DATA_FILE, "r", encoding="utf-8") as f:
             return json.load(f)
     return {}
 
+
 def save_ids(data):
     with open(DATA_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
+
 def get_id(key):
     data = load_ids()
     return data.get(key)
+
 
 def set_id(key, value):
     data = load_ids()


### PR DESCRIPTION
## Summary
- run `black` to clean up formatting
- optimize crop catalog lookups by using a dictionary

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_685e0c3dcf74832b880a1a41a0e77f4d