### PR TITLE
Fix field status filtering by farm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ FTP_USER=username
 FTP_PASS=secret
 FTP_PATH=/profile/savegame1/vehicles.xml
 FTP_PATH_FIELDS=/profile/savegame1/fields.xml
+FARM_ID=1
 ```
 
 Если значение всё же содержит кавычки, бот удалит их автоматически при загрузке настроек.

--- a/modules/fields.py
+++ b/modules/fields.py
@@ -2,6 +2,8 @@ import json
 import xml.etree.ElementTree as ET
 from typing import Dict, List
 
+from config import config
+
 # Загрузка JSON с каталогом культур
 with open("data/crops_catalog.json", "r", encoding="utf-8") as f:
     _CATALOG: Dict[str, dict] = {c["nameXML"]: c for c in json.load(f)}
@@ -30,7 +32,7 @@ def parse_field_statuses(xml_bytes: bytes) -> List[str]:
     results = []
 
     for field in fields:
-        if field.get("farmId") != "1":
+        if field.get("farmId") != config.FARM_ID:
             continue
 
         field_id = field.get("id")


### PR DESCRIPTION
## Summary
- load FARM_ID config in fields parsing module
- filter fields using configured farm ID
- document FARM_ID env variable in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e11523be8832ba73a820ef090909d