### PR TITLE
Unify FTP polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ FTP_PASS=secret
 FTP_PATH=/profile/savegame1/vehicles.xml
 FTP_PATH_FIELDS=/profile/savegame1/fields.xml
 FARM_ID=1
+FTP_POLL_INTERVAL=300
 ```
 
 Если значение всё же содержит кавычки, бот удалит их автоматически при загрузке настроек.

--- a/config/config.py
+++ b/config/config.py
@@ -21,7 +21,8 @@ FTP_PATH_FIELDS = _get_env("FTP_PATH_FIELDS")
 
 FARM_ID = os.getenv("FARM_ID", "1")
 
-CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "600"))
+# Interval between FTP polling requests in seconds
+FTP_POLL_INTERVAL = int(os.getenv("FTP_POLL_INTERVAL", "300"))
 
 DATA_DIR = os.getenv("DATA_DIR", "data")
 VEHICLES_FILE = os.getenv("VEHICLES_FILE", "filtered_vehicles.json")


### PR DESCRIPTION
## Summary
- add a single `FTP_POLL_INTERVAL` option to control delay between FTP checks
- use the new interval in the main loop and drop custom sleeps
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862022b9664832b9c82fd394b39aacc