### PR TITLE
Fix bot startup for discord.py 2.x

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,17 +5,24 @@ from config.config import config
 from bot.updater import update_message
 
 
-class FSBot(discord.Client):
+# Собственный класс клиента, где мы можем запускать фоновые задачи
+class MyBot(discord.Client):
+    async def setup_hook(self) -> None:
+        """Вызывается Discord.py при подготовке клиента."""
+        # Запускаем обновление сообщения как отдельную асинхронную задачу
+        asyncio.create_task(update_message(self))
+
     async def on_ready(self):
+        # Сообщаем в консоль, что бот успешно авторизовался
         print(f"Logged in as {self.user}")
 
 
-def main():
-    intents = discord.Intents.default()
-    bot = FSBot(intents=intents)
-    bot.loop.create_task(update_message(bot))
-    bot.run(config.discord_token)
-
-
 if __name__ == "__main__":
-    main()
+    # Создаём объект намерений и включаем необходимые события
+    intents = discord.Intents.default()
+    intents.messages = True
+    intents.guilds = True
+
+    # Инициализируем бота и запускаем его
+    bot = MyBot(intents=intents)
+    bot.run(config.discord_token)


### PR DESCRIPTION
## Summary
- refactor `main.py` to use `setup_hook` instead of `loop.create_task`
- run the bot directly in the `__main__` block and configure needed intents

## Testing
- `python -m py_compile main.py`
- `python -m py_compile bot/discord_ui.py bot/fetchers.py bot/parsers.py bot/updater.py config/config.py ftp/fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f377d31c832b93f6d6fb778b2e8b