### PR TITLE
Implement message replacement

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -54,10 +54,19 @@ async def update_message(bot: discord.Client):
 
                 embed = build_embed(map_name or "?", day or 0, time_str or "?", vehicle_count, balance or 0, diff or 0)
 
-                if message is None:
-                    message = await channel.send(embed=embed)
-                    save_message_id(message.id)
-                else:
-                    await message.edit(embed=embed)
+                # Если есть предыдущее сообщение, пытаемся удалить его
+                if message is not None:
+                    try:
+                        await message.delete()
+                    except discord.NotFound:
+                        # Сообщение уже удалено или не существует
+                        pass
+                    except Exception as e:
+                        # Логируем ошибку, но продолжаем работу цикла
+                        print(f"⚠ Не удалось удалить сообщение: {e}")
+
+                # Отправляем новый embed и сохраняем его ID
+                message = await channel.send(embed=embed)
+                save_message_id(message.id)
 
             await asyncio.sleep(config.ftp_poll_interval)


### PR DESCRIPTION
## Summary
- replace editing the previous embed with deleting it and sending a new one
- log deletion problems without stopping the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68654b37729c832bbe165adbc8b1bbcf