### PR TITLE
Fix XML and FTP fetching

### DIFF
--- a/bot/fetchers.py
+++ b/bot/fetchers.py
@@ -4,10 +4,12 @@ from config.config import config
 
 # Загружает XML-файл с сервера Farming Simulator по имени файла (например, "vehicles")
 async def fetch_xml(session: aiohttp.ClientSession, file: str) -> Optional[str]:
-    """
-    Загружает XML по ссылке: BASE_URL?code=...&file=...
-    """
-    url = f"{config.api_base_url}?code={config.api_secret_code}&file={file}"
+    """Загружает XML по ссылке BASE_URL?code=...&file=..."""
+
+    if file:
+        url = f"{config.api_base_url}?code={config.api_secret_code}&file={file}"
+    else:
+        url = f"{config.api_base_url}?code={config.api_secret_code}"
 
     try:
         async with session.get(url) as resp:

--- a/bot/updater.py
+++ b/bot/updater.py
@@ -22,7 +22,7 @@ async def update_message(bot: discord.Client):
     async with aiohttp.ClientSession() as session:
         while not bot.is_closed():
             # Загружаем XML-файлы с API
-            stats_xml = await fetch_xml(session, "serverStats")
+            stats_xml = await fetch_xml(session, "")
             career_xml = await fetch_career_savegame(session)
             vehicles_xml = await fetch_vehicles(session)
             economy_xml = await fetch_economy(session)


### PR DESCRIPTION
## Summary
- correct server stats API call
- update message updater to use new API URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865765266e4832bbf1f1f1fa6c657ca