### PR TITLE
Refactor and cleanup

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -4,40 +4,32 @@ from typing import Any, Dict
 import discord
 
 
+def format_money(amount: Any) -> str:
+    """Форматирование суммы денег."""
+    try:
+        amount = int(amount)
+    except (ValueError, TypeError):
+        return str(amount) if amount is not None else "—"
+    return f"{amount:,} $".replace(",", " ")
+
+
 def build_embed(data: Dict[str, Any]) -> discord.Embed:
     """Формирует embed по данным, полученным из ``parse_all``."""
 
     # Извлекаем данные из словаря или ставим прочерк, если их нет
     server_name = data.get("server_name") or "—"
     map_name = data.get("map_name") or "—"
-    print(f"[DEBUG PARSE_ALL] Сервер: {server_name}, Карта: {map_name}")
     slots_used = data.get("slots_used")
     slots_max = data.get("slots_max")
     farm_money = data.get("farm_money")
-    def format_money(amount):
-        try:
-            amount = int(amount)
-        except Exception:
-            return str(amount)
-        return f"{amount:,} $".replace(",", " ")
-    profit = data.get("profit")
-    profit_positive = data.get("profit_positive")
     fields_owned = data.get("fields_owned")
     fields_total = data.get("fields_total")
     vehicles_owned = data.get("vehicles_owned")
-    last_updated = data.get("last_updated") or "—"
+    last_month_profit = data.get("last_month_profit")
 
     slots_str = f"{slots_used if slots_used is not None else '—'} / {slots_max if slots_max is not None else '—'}"
 
-# Форматируем прибыль с учётом знака и emoji
-    if profit is None:
-        profit_str = "—"
-    else:
-        emoji = "🟢" if profit_positive is True else "🔴" if profit_positive is False else "—"
-        profit_str = f"{profit:+} {emoji}"
-
 # Формируем строку для денег фермы и прибыли за последний месяц
-    last_month_profit = data.get("last_month_profit")
     if last_month_profit is not None:
         sign = "+" if last_month_profit >= 0 else "−"
         formatted_profit = f"{sign}{abs(last_month_profit):,} $".replace(",", " ")
@@ -59,10 +51,15 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
         ]
     )
 
+    if last_month_profit is not None:
+        color = discord.Color.green() if last_month_profit >= 0 else discord.Color.red()
+    else:
+        color = discord.Color.blue()
+
     embed = discord.Embed(
         title="Состояние сервера Farming Simulator",
         description=description,
-        color=0x00AAFF,
+        color=color,
     )
 
     # Добавляем информацию о времени обновления бота

--- a/bot/fetchers.py
+++ b/bot/fetchers.py
@@ -1,28 +1,30 @@
 import aiohttp
+
 from config.config import config
+from .logger import log_debug
 
 async def fetch_stats_xml(session):
     url = f"{config.api_base_url.replace('dedicated-server-savegame.html', 'dedicated-server-stats.xml')}?code={config.api_secret_code}"
-    print(f"[API] Загружаем stats.xml по адресу: {url}")
+    log_debug(f"[API] Загружаем stats.xml по адресу: {url}")
     try:
         async with session.get(url) as resp:
             resp.raise_for_status()
             data = await resp.text()
-            print("[API] stats.xml загружен успешно.")
+            log_debug("[API] stats.xml загружен успешно.")
             return data
     except Exception as e:
-        print(f"[API] ❌ Ошибка загрузки stats.xml: {e}")
+        log_debug(f"[API] ❌ Ошибка загрузки stats.xml: {e}")
         return None
 
 async def fetch_api_file(session, filename):
     url = f"{config.api_base_url}?file={filename}&code={config.api_secret_code}"
-    print(f"[API] Загружаем файл {filename} по адресу: {url}")
+    log_debug(f"[API] Загружаем файл {filename} по адресу: {url}")
     try:
         async with session.get(url) as resp:
             resp.raise_for_status()
             data = await resp.text()
-            print(f"[API] {filename} загружен успешно.")
+            log_debug(f"[API] {filename} загружен успешно.")
             return data
     except Exception as e:
-        print(f"[API] ❌ Ошибка загрузки {filename}: {e}")
+        log_debug(f"[API] ❌ Ошибка загрузки {filename}: {e}")
         return None

--- a/bot/logger.py
+++ b/bot/logger.py
@@ -1,0 +1,2 @@
+def log_debug(message: str) -> None:
+    print(message)

--- a/bot/parsers.py
+++ b/bot/parsers.py
@@ -1,64 +1,7 @@
 import xml.etree.ElementTree as ET
 from typing import Tuple, Optional, Dict
 
-
-def parse_career_savegame(xml_text: str) -> Tuple[Optional[str], Optional[int], Optional[str]]:
-    """Return map name, day number and time string."""
-    root = ET.fromstring(xml_text)
-    map_name = None
-    day = None
-    time = None
-
-    # пробуем несколько вариантов для совместимости разных версий
-    for tag in ("mapName", "mapTitle", "name"):
-        elem = root.find(f".//{tag}")
-        if elem is not None and elem.text:
-            map_name = elem.text
-            break
-
-    for tag in ("day", "currentDay", "dayNumber"):
-        elem = root.find(f".//{tag}")
-        if elem is not None and elem.text:
-            try:
-                day = int(elem.text)
-            except ValueError:
-                pass
-            break
-
-    for tag in ("time", "currentTime", "dayTime"):
-        elem = root.find(f".//{tag}")
-        if elem is not None and elem.text:
-            time = elem.text
-            break
-
-    return map_name, day, time
-
-
-def parse_vehicles_count(xml_text: str) -> int:
-    root = ET.fromstring(xml_text)
-    return len(root.findall('.//vehicle'))
-
-
-def parse_economy(xml_text: str) -> Tuple[Optional[int], Optional[int]]:
-    """Return current balance and last day income (difference)."""
-    root = ET.fromstring(xml_text)
-    money_nodes = root.findall('.//money')
-    if not money_nodes:
-        return None, None
-
-    try:
-        current_balance = int(float(money_nodes[-1].text))
-    except (ValueError, TypeError):
-        current_balance = None
-
-    money_change = None
-    if len(money_nodes) >= 2:
-        try:
-            prev = int(float(money_nodes[-2].text))
-            money_change = current_balance - prev if current_balance is not None else None
-        except (ValueError, TypeError):
-            pass
-    return current_balance, money_change
+from .logger import log_debug
 
 
 def parse_server_stats(xml_text: str) -> Tuple[Optional[str], Optional[str], Optional[int], Optional[int], Optional[str]]:
@@ -104,28 +47,6 @@ def parse_farm_money(xml_text: str) -> Optional[int]:
     return None
 
 
-def parse_daily_profit(xml_text: str) -> Tuple[Optional[int], Optional[bool]]:
-    """Возвращает прибыль последнего дня и флаг её знака."""
-    root = ET.fromstring(xml_text)
-    stats = root.findall('.//dailyStat')
-    if not stats:
-        return None, None
-
-    last = stats[-1]
-    income = last.get('income') or last.get('earnings')
-    expenses = last.get('expenses') or last.get('costs')
-
-    try:
-        inc = int(float(income)) if income is not None else 0
-    except (ValueError, TypeError):
-        inc = 0
-    try:
-        exp = int(float(expenses)) if expenses is not None else 0
-    except (ValueError, TypeError):
-        exp = 0
-
-    profit = inc - exp
-    return profit, profit >= 0
 
 
 def _count_vehicles(xml_text: str, farm_id: str) -> Optional[int]:
@@ -158,45 +79,6 @@ def parse_farmland(xml_text: str, farm_id: str) -> Tuple[int, int]:
     owned = len([f for f in farmlands if f.get('owner') == farm_id])
     return owned, total
 
-def parse_month_profit(farms_xml: str, farm_id: str = '1', days_per_month: int = 30) -> Tuple[int, str]:
-    """
-    Считает суммарную прибыль/убыток за игровой месяц по farms.xml.
-    Возвращает (прибыль, диапазон дней или название месяца).
-    """
-    root = ET.fromstring(farms_xml)
-    farm_elem = None
-    for farm in root.findall('.//farm'):
-        if farm.get('farmId') == farm_id:
-            farm_elem = farm
-            break
-    if farm_elem is None:
-        return 0, "?"
-
-    finances = farm_elem.find('finances')
-    if finances is None:
-        return 0, "?"
-
-    stats_elems = finances.findall('stats')
-    if not stats_elems:
-        return 0, "?"
-
-    # определяем последний игровой день
-    last_day = int(stats_elems[-1].attrib["day"])
-    # начало месяца (каждые 30 дней)
-    month_start = ((last_day - 1) // days_per_month) * days_per_month + 1
-    month_end = month_start + days_per_month - 1
-
-    profit = 0.0
-    for stats in stats_elems:
-        day = int(stats.attrib["day"])
-        if month_start <= day <= month_end:
-            for child in stats:
-                try:
-                    profit += float(child.text)
-                except (TypeError, ValueError):
-                    continue
-    month_name = f"дни {month_start}-{min(month_end, last_day)}"
-    return int(profit), month_name
 
 def parse_last_month_profit(xml_text: str) -> Optional[int]:
     """Возвращает округлённую прибыль за последний месяц (day=0) из farms.xml"""
@@ -218,9 +100,7 @@ def parse_last_month_profit(xml_text: str) -> Optional[int]:
 
 def parse_all(
     server_stats: str,
-    career_savegame_api: str,
     vehicles_api: str,
-    economy_api: str,
     career_savegame_ftp: str,
     farmland_ftp: str,
     vehicles_ftp: Optional[str] = None,
@@ -229,43 +109,30 @@ def parse_all(
 ) -> Dict[str, Optional[int]]:
     """Собирает все данные из разных источников и возвращает единую структуру."""
 
-    server_name, map_name, slots_used, slots_max, last_updated = parse_server_stats(server_stats)
+    server_name, map_name, slots_used, slots_max, _ = parse_server_stats(server_stats)
 
     farm_money = parse_farm_money(career_savegame_ftp)
-
-    profit, positive = parse_daily_profit(economy_api)
 
     fields_owned, fields_total = parse_farmland(farmland_ftp, farm_id)
 
     vehicles_owned = _count_vehicles(vehicles_api, farm_id)
     if vehicles_owned is None and vehicles_ftp is not None:
         vehicles_owned = _count_vehicles(vehicles_ftp, farm_id)
-    if vehicles_owned is None:
-        vehicles_owned = 0
+    vehicles_owned = vehicles_owned or 0
 
-    print(f"[DEBUG PARSE_ALL] Сервер: {server_name}, Карта: {map_name}")
+    log_debug(f"[PARSE_ALL] Сервер: {server_name}, Карта: {map_name}")
 
-        # Расчёт месячной прибыли
-    month_profit, month_period = 0, "-"
-    if farms_xml is not None:
-        month_profit, month_period = parse_month_profit(farms_xml, farm_id)
-        last_month_profit = parse_last_month_profit(farms_xml)
+    last_month_profit = parse_last_month_profit(farms_xml) if farms_xml is not None else None
 
-    result = {
-        'month_profit': month_profit,
-        'month_period': month_period,
+    return {
         'last_month_profit': last_month_profit,
         'server_name': server_name,
         'map_name': map_name,
         'slots_used': slots_used,
         'slots_max': slots_max,
         'farm_money': farm_money,
-        'profit': profit,
-        'profit_positive': positive,
         'fields_owned': fields_owned,
         'fields_total': fields_total,
         'vehicles_owned': vehicles_owned,
-        'last_updated': last_updated,
     }
 
-    return result

--- a/ftp/fetcher.py
+++ b/ftp/fetcher.py
@@ -1,9 +1,11 @@
 import aioftp
 from typing import Optional
+
 from config.config import config
+from bot.logger import log_debug
 
 async def fetch_file(file_name: str) -> Optional[str]:
-    print(f"[FTP] Пробуем подключиться к {config.ftp_host}:{config.ftp_port} как {config.ftp_user}")
+    log_debug(f"[FTP] Пробуем подключиться к {config.ftp_host}:{config.ftp_port} как {config.ftp_user}")
     try:
         async with aioftp.Client.context(
             config.ftp_host,
@@ -11,16 +13,16 @@ async def fetch_file(file_name: str) -> Optional[str]:
             user=config.ftp_user,
             password=config.ftp_pass,
         ) as ftp_client:
-            print("[FTP] Заходим в папку profile...")
+            log_debug("[FTP] Заходим в папку profile...")
             await ftp_client.change_directory("profile")
-            print("[FTP] Заходим в папку savegame1...")
+            log_debug("[FTP] Заходим в папку savegame1...")
             await ftp_client.change_directory("savegame1")
-            print(f"[FTP] Содержимое папки: {[f async for f in ftp_client.list()]}")
-            print(f"[FTP] Пробуем скачать файл: {file_name}")
+            log_debug(f"[FTP] Содержимое папки: {[f async for f in ftp_client.list()]}")
+            log_debug(f"[FTP] Пробуем скачать файл: {file_name}")
             async with ftp_client.download_stream(file_name) as stream:
                 content = await stream.read()
-                print(f"[FTP] Файл {file_name} скачан успешно. Размер: {len(content)} байт")
+                log_debug(f"[FTP] Файл {file_name} скачан успешно. Размер: {len(content)} байт")
                 return content.decode("utf-8")
     except Exception as e:
-        print(f"[FTP] ❌ Ошибка загрузки файла '{file_name}': {e}")
+        log_debug(f"[FTP] ❌ Ошибка загрузки файла '{file_name}': {e}")
         return None

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import asyncio
 
 from config.config import config
 from bot.updater import update_message
+from bot.logger import log_debug
 
 
 # Собственный класс клиента, где мы можем запускать фоновые задачи
@@ -14,7 +15,7 @@ class MyBot(discord.Client):
 
     async def on_ready(self):
         # Сообщаем в консоль, что бот успешно авторизовался
-        print(f"Logged in as {self.user}")
+        log_debug(f"Logged in as {self.user}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove unused parser helpers and profit logic
- simplify `parse_all` and unify logging
- add small logger helper
- tweak embed formatting and color logic
- drop redundant API calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866f60224e0832bb9b273a83bcb37e0