### PR TITLE
Add online history graph generation

### DIFF
--- a/bot/online_history.py
+++ b/bot/online_history.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 import asyncio
 
 import aiofiles
@@ -12,10 +12,7 @@ import matplotlib.pyplot as plt
 
 async def update_online_history_hourly(current_online: int, history_file: str = "online_stats.json") -> bool:
     """Сохраняет онлайн раз в час. Возвращает True, если добавлена новая запись."""
-    now = datetime.now()
-    if now.minute != 0:
-        return False
-    now_str = now.strftime("%Y-%m-%d %H:00")
+    now_str = datetime.now().strftime("%Y-%m-%d %H:00")
     try:
         async with aiofiles.open(history_file, "r", encoding="utf-8") as f:
             content = await f.read()
@@ -24,7 +21,7 @@ async def update_online_history_hourly(current_online: int, history_file: str = 
         history = []
     if history and history[-1].get("time") == now_str:
         return False
-    history.append({"time": now_str, "online": current_online})
+    history.append({"time": now_str, "online": int(current_online)})
     if len(history) > 24:
         history = history[-24:]
     async with aiofiles.open(history_file, "w", encoding="utf-8") as f:
@@ -32,15 +29,22 @@ async def update_online_history_hourly(current_online: int, history_file: str = 
     return True
 
 
+from matplotlib.ticker import MaxNLocator
+
+
 def _plot(times, online, image_file):
-    plt.figure(figsize=(8, 3))
-    plt.plot(times, online, marker="o")
-    plt.title("Онлайн за последние 24 часа (почасовой срез)")
-    plt.xlabel("Время")
-    plt.ylabel("Игроков онлайн")
-    plt.xticks(rotation=45, fontsize=8)
+    plt.figure(figsize=(9, 3))
+    ax = plt.gca()
+    ax.plot(range(len(times)), online, marker="o")
+    ax.set_title("Онлайн за последние 24 часа (почасовой срез)")
+    ax.set_xlabel("Время")
+    ax.set_ylabel("Игроков онлайн")
+    ax.set_xticks(range(len(times)))
+    ax.set_xticklabels(times, rotation=45, ha="right", fontsize=8)
+    ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    ax.set_ylim(bottom=0)
+    ax.grid(True)
     plt.tight_layout()
-    plt.grid(True)
     plt.savefig(image_file)
     plt.close()
 
@@ -52,11 +56,20 @@ async def make_online_graph(history_file: str = "online_stats.json", image_file:
             content = await f.read()
             history = json.loads(content)
     except Exception:
-        return None
-    if not history or len(history) < 2:
-        return None
-    times = [h["time"][-5:] for h in history]
-    online = [h["online"] for h in history]
+        history = []
+
+    # Формируем словарь исторических значений
+    history_dict = {h["time"]: int(h.get("online", 0)) for h in history}
+
+    now = datetime.now().replace(minute=0, second=0, microsecond=0)
+    times = []
+    online = []
+    for i in range(23, -1, -1):
+        point_time = now - timedelta(hours=i)
+        key = point_time.strftime("%Y-%m-%d %H:00")
+        times.append(point_time.strftime("%H:00"))
+        online.append(history_dict.get(key, 0))
+
     loop = asyncio.get_event_loop()
     await loop.run_in_executor(None, _plot, times, online, image_file)
     return image_file

--- a/bot/updater.py
+++ b/bot/updater.py
@@ -1,5 +1,6 @@
 import aiohttp
 import asyncio
+from pathlib import Path
 import discord         # <--- ВОТ ЭТА СТРОКА!
 from config.config import config
 from ftp.fetcher import fetch_file
@@ -49,9 +50,14 @@ async def update_message(bot: discord.Client):
                     dedicated_server_stats=dedicated_server_stats_ftp,
                 )
                 # Логируем онлайн раз в час
-                await update_online_history_hourly(len(data.get("players_online", [])))
+                history_updated = await update_online_history_hourly(
+                    len(data.get("players_online", []))
+                )
                 embed = build_embed(data)
-                graph_file = await make_online_graph()
+                if history_updated or not Path("online_graph.png").exists():
+                    graph_file = await make_online_graph()
+                else:
+                    graph_file = "online_graph.png"
 
                 async for msg in channel.history(limit=None):
                     try:


### PR DESCRIPTION
## Summary
- track hourly online counts
- generate 24‑point graph with matplotlib
- reuse last generated graph if history didn't change

## Testing
- `python -m py_compile bot/online_history.py bot/updater.py`


------
https://chatgpt.com/codex/tasks/task_e_68691312bfc0832bbab95630f7b746f2