### PR TITLE
Add server status to embed

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -42,17 +42,17 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
     vehicles_str = f"{vehicles_owned if vehicles_owned is not None else '—'}"
 
     # Текст embed'a формируем единой строкой
-    description = "\n".join(
-        [
-            f"🧷 **Сервер:** {server_name}",
-            f"🗺️ **Карта:** {map_name}",
-            f"💰 **Деньги фермы:** {money_str}",
-            f"🌾 **Поля во владении:** {fields_str}",
-            f"🚜 **Техника:** {vehicles_str} единиц",
-            f"👥 **Слоты:** {slots_str}",
-            f"👥 **Онлайн:** {', '.join(players_online) if players_online else 'никого нет'}",
-        ]
-    )
+    lines = [
+        data.get("server_status", "—"),
+        f"🧷 **Сервер:** {server_name}",
+        f"🗺️ **Карта:** {map_name}",
+        f"💰 **Деньги фермы:** {money_str}",
+        f"🌾 **Поля во владении:** {fields_str}",
+        f"🚜 **Техника:** {vehicles_str} единиц",
+        f"👥 **Слоты:** {slots_str}",
+        f"👥 **Онлайн:** {', '.join(players_online) if players_online else 'никого нет'}",
+    ]
+    description = "\n".join(lines)
 
     if last_month_profit is not None:
         color = discord.Color.green() if last_month_profit >= 0 else discord.Color.red()


### PR DESCRIPTION
## Summary
- show the server status in the Discord embed
- always build an embed even when fetching data fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68698f8ebf0c832b8ccb4341b0b2239b