### PR TITLE
Always use green embed color

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -54,15 +54,10 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
     ]
     description = "\n".join(lines)
 
-    if last_month_profit is not None:
-        color = discord.Color.green() if last_month_profit >= 0 else discord.Color.red()
-    else:
-        color = discord.Color.blue()
-
     embed = discord.Embed(
         title="Состояние сервера Farming Simulator",
         description=description,
-        color=color,
+        color=discord.Color.green(),
     )
 
     # Добавляем информацию о времени обновления бота


### PR DESCRIPTION
## Summary
- ensure embed color is always green in `build_embed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869abe350b0832b876b93aa890737f9