### PR TITLE
Switch bot to Moscow timezone

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -1,5 +1,6 @@
-from datetime import datetime
 from typing import Any, Dict
+
+from utils.helpers import get_moscow_time
 
 import discord
 
@@ -60,7 +61,7 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
         color=discord.Color.green(),
     )
 
-    # Добавляем информацию о времени обновления бота
-    embed.set_footer(text=f"Последнее обновление: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    # Добавляем информацию о времени обновления бота (московское время)
+    embed.set_footer(text=f"Последнее обновление: {get_moscow_time()}")
 
     return embed

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timedelta
+
+
+def get_moscow_time() -> str:
+    """Возвращает текущее московское время в формате YYYY-MM-DD HH:MM:SS."""
+    return (datetime.utcnow() + timedelta(hours=3)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_moscow_datetime() -> datetime:
+    """Возвращает объект datetime с текущим московским временем."""
+    return datetime.utcnow() + timedelta(hours=3)

--- a/utils/online_history.py
+++ b/utils/online_history.py
@@ -1,7 +1,9 @@
 """Функции для хранения и визуализации истории онлайна."""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
+
+from utils.helpers import get_moscow_datetime
 
 import asyncpg
 import matplotlib
@@ -13,7 +15,8 @@ from matplotlib.ticker import MaxNLocator
 
 async def insert_online_players(db_pool: asyncpg.Pool, players: list[str]) -> None:
     """Сохраняет онлайн игроков в таблицу ``player_online_history``."""
-    now = datetime.now()
+    # Текущее время в Москве
+    now = get_moscow_datetime()
     slot_start = now - timedelta(
         minutes=now.minute % 15, seconds=now.second, microseconds=now.microsecond
     )
@@ -64,7 +67,8 @@ async def make_online_graph(db_pool: asyncpg.Pool, image_file: str = "online_gra
         )
 
     data = {r["hour"].replace(minute=0, second=0, microsecond=0): r["cnt"] for r in rows}
-    now = datetime.now().replace(minute=0, second=0, microsecond=0)
+    # Текущее московское время без минут и секунд
+    now = get_moscow_datetime().replace(minute=0, second=0, microsecond=0)
     times = []
     online = []
     for i in range(23, -1, -1):


### PR DESCRIPTION
## Summary
- add `get_moscow_time` and `get_moscow_datetime` helpers
- use Moscow time when building Discord embeds
- store and display history timestamps in Moscow timezone

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686beb252790832b83917f108828619f