### PR TITLE
Implement player total time aggregation

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -10,3 +10,11 @@ CREATE TABLE IF NOT EXISTS player_top_week (
     activity_hours INTEGER NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );
+
+-- Таблица общего времени игры
+CREATE TABLE IF NOT EXISTS player_total_time (
+    id SERIAL PRIMARY KEY,
+    player_name TEXT UNIQUE NOT NULL,
+    total_hours INTEGER NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);

--- a/utils/total_time.py
+++ b/utils/total_time.py
@@ -1,0 +1,61 @@
+"""Подсчёт суммарного времени, проведённого игроками на сервере."""
+
+from collections import defaultdict
+from typing import Dict
+
+import asyncpg
+
+
+async def update_player_total_time(db_pool: asyncpg.Pool) -> None:
+    """Пересчитывает общее время игры каждого игрока.
+
+    Правила расчёта:
+    - таблица ``player_online_history`` содержит фиксации онлайна каждые 15 минут;
+    - если в течение часа игрок встретился три раза и более, час засчитывается;
+    - в ``player_total_time`` суммируется количество таких часов.
+    """
+
+    # Получаем полную статистику по часам для каждого игрока
+    async with db_pool.acquire() as conn:
+        hourly_rows = await conn.fetch(
+            """
+            SELECT player_name, DATE_TRUNC('hour', check_time) AS hour, COUNT(*) AS cnt
+            FROM player_online_history
+            GROUP BY player_name, hour
+            HAVING COUNT(*) >= 3
+            """
+        )
+
+        # Текущие значения общих часов в базе
+        existing_rows = await conn.fetch(
+            "SELECT player_name, total_hours FROM player_total_time"
+        )
+
+    # Считаем зачтённые часы по данным истории
+    hours_by_player: Dict[str, int] = defaultdict(int)
+    for row in hourly_rows:
+        hours_by_player[row["player_name"]] += 1
+
+    current_totals: Dict[str, int] = {
+        row["player_name"]: row["total_hours"] for row in existing_rows
+    }
+
+    # Вносим обновления только если появилось новое время
+    async with db_pool.acquire() as conn:
+        for name, total in hours_by_player.items():
+            increment = total - current_totals.get(name, 0)
+            if increment <= 0:
+                continue
+
+            await conn.execute(
+                """
+                INSERT INTO player_total_time (player_name, total_hours, updated_at)
+                VALUES ($1, $2, NOW())
+                ON CONFLICT (player_name) DO UPDATE
+                SET total_hours = player_total_time.total_hours + $2,
+                    updated_at = NOW()
+                """,
+                name,
+                increment,
+            )
+


### PR DESCRIPTION
## Summary
- add `player_total_time` table to DB schema
- implement async function `update_player_total_time` for computing hours from `player_online_history`

## Testing
- `python -m py_compile utils/total_time.py`

------
https://chatgpt.com/codex/tasks/task_e_686bfd3ac6dc832bb10ac7a8d25cfb14