### PR TITLE
Add on-demand leaderboard commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,10 +5,10 @@ import discord
 
 from config.config import config
 import asyncpg
-from bot.updater import ftp_polling_task, api_polling_task, weekly_top_task
+from bot.updater import ftp_polling_task, api_polling_task
 from utils.logger import log_debug
-from utils.top_week import get_player_top_week
-from bot.discord_ui import build_top_week_embed
+from utils.total_time import get_player_total_top
+from utils.top_image import draw_top_image
 
 
 class MyBot(discord.Client):
@@ -17,7 +17,6 @@ class MyBot(discord.Client):
         self.db_pool = await asyncpg.create_pool(dsn=config.postgres_url)
         asyncio.create_task(api_polling_task(self.db_pool))
         asyncio.create_task(ftp_polling_task(self, self.db_pool))
-        asyncio.create_task(weekly_top_task(self, self.db_pool))
 
     async def on_ready(self):
         log_debug(f"Discord-бот авторизован как {self.user}")
@@ -25,10 +24,30 @@ class MyBot(discord.Client):
     async def on_message(self, message: discord.Message):
         if message.author == self.user:
             return
-        if message.content.lower().startswith('/topweek'):
-            top, updated_at = await get_player_top_week(self.db_pool)
-            embed = build_top_week_embed(top, updated_at)
-            await message.channel.send(embed=embed)
+
+        content = message.content.lower()
+
+        # Команда топа за 7 дней
+        if content.startswith('!top7'):
+            rows = await self.db_pool.fetch(
+                "SELECT player_name, activity_hours FROM player_top_week "
+                "ORDER BY activity_hours DESC LIMIT 10"
+            )
+            img = draw_top_image(list(rows), title='ТОП-10 за неделю', size=10, key='activity_hours')
+            file = discord.File(fp=img, filename='top7.png')
+            embed = discord.Embed(title='ТОП-10 активных игроков за неделю')
+            embed.set_image(url='attachment://top7.png')
+            await message.channel.send(embed=embed, file=file)
+            return
+
+        # Команда топа за всё время
+        if content.startswith('!top'):
+            rows = await get_player_total_top(self.db_pool, limit=50)
+            img = draw_top_image(list(rows), title='ТОП-50 по общему времени', size=50, key='total_hours')
+            file = discord.File(fp=img, filename='top.png')
+            embed = discord.Embed(title='ТОП-50 по общему времени на сервере')
+            embed.set_image(url='attachment://top.png')
+            await message.channel.send(embed=embed, file=file)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aioftp
 matplotlib
 aiofiles
 asyncpg
+Pillow

--- a/utils/top_image.py
+++ b/utils/top_image.py
@@ -1,0 +1,59 @@
+"""Отрисовка изображений с таблицей топа игроков."""
+
+from typing import List, Dict
+from PIL import Image, ImageDraw, ImageFont
+import io
+
+
+FONT = ImageFont.load_default()
+
+
+def draw_top_image(rows: List[Dict], title: str, size: int, key: str) -> io.BytesIO:
+    """Рисует PNG-таблицу топа игроков.
+
+    Args:
+        rows: Список строк из базы данных.
+        title: Заголовок таблицы.
+        size: Количество строк (10 или 50).
+        key: Имя колонки со значением часов.
+    Returns:
+        BytesIO с изображением PNG.
+    """
+    # Размеры строк и шапки
+    header_h = 40
+    row_h = 40
+    width = 400
+    height = header_h + row_h * size
+
+    # Создаём холст
+    img = Image.new("RGB", (width, height), color="white")
+    draw = ImageDraw.Draw(img)
+
+    # Заголовок
+    draw.rectangle([0, 0, width, header_h], fill=(200, 200, 200))
+    draw.text((10, 10), title, font=FONT, fill="black")
+
+    # Рисуем строки
+    for i in range(size):
+        y = header_h + i * row_h
+        # Подложка через одну строку
+        if i % 2 == 0:
+            draw.rectangle([0, y, width, y + row_h], fill=(240, 240, 240))
+
+        place = str(i + 1)
+        if i < len(rows):
+            name = rows[i]["player_name"]
+            hours = rows[i][key]
+        else:
+            name = "-"
+            hours = "-"
+
+        draw.text((10, y + 10), f"{place}. {name}", font=FONT, fill="black")
+        hours_text = f"{hours} ч" if hours != "-" else "-"
+        text_w, _ = draw.textsize(hours_text, font=FONT)
+        draw.text((width - text_w - 10, y + 10), hours_text, font=FONT, fill="black")
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf

--- a/utils/total_time.py
+++ b/utils/total_time.py
@@ -59,3 +59,13 @@ async def update_player_total_time(db_pool: asyncpg.Pool) -> None:
                 increment,
             )
 
+
+async def get_player_total_top(db_pool: asyncpg.Pool, limit: int = 50):
+    """Возвращает топ игроков по общему времени."""
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT player_name, total_hours FROM player_total_time "
+            "ORDER BY total_hours DESC LIMIT $1",
+            limit,
+        )
+    return rows


### PR DESCRIPTION
## Summary
- add `draw_top_image` helper for rendering leaderboard tables
- show weekly and total playtime leaderboards on `!top7` and `!top` commands
- remove automatic leaderboard posting
- add Pillow dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686bffbb40bc832bb7bec39ccdf07a35