### PR TITLE
Fix /top commands when using Pillow 10

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,11 +43,19 @@ async def cmd_top7(interaction: discord.Interaction):
         if not rows:
             await interaction.followup.send("Данных нет", ephemeral=True)
             return
-        img = draw_top_image(list(rows), title="ТОП-10 за неделю", size=10, key="activity_hours")
-        file = discord.File(fp=img, filename="top7.png")
-        embed = discord.Embed(title="ТОП-10 активных игроков за неделю")
-        embed.set_image(url="attachment://top7.png")
-        await interaction.followup.send(embed=embed, file=file)
+        try:
+            img = draw_top_image(list(rows), title="ТОП-10 за неделю", size=10, key="activity_hours")
+            file = discord.File(fp=img, filename="top7.png")
+            embed = discord.Embed(title="ТОП-10 активных игроков за неделю")
+            embed.set_image(url="attachment://top7.png")
+            await interaction.followup.send(embed=embed, file=file)
+        except Exception:
+            lines = [f"{i+1}. {row['player_name']} - {row['activity_hours']} ч" for i, row in enumerate(rows)]
+            text = "\n".join(lines)
+            await interaction.followup.send(
+                f"Не удалось сгенерировать картинку, вот текстовый топ:\n{text}",
+                ephemeral=True,
+            )
     except Exception as e:
         log_debug(f"[ERROR] /top7: {e}")
         await interaction.followup.send("Произошла ошибка при выполнении команды.", ephemeral=True)
@@ -63,11 +71,19 @@ async def cmd_top(interaction: discord.Interaction):
         if not rows:
             await interaction.followup.send("Данных нет", ephemeral=True)
             return
-        img = draw_top_image(list(rows), title="ТОП-50 по общему времени", size=50, key="total_hours")
-        file = discord.File(fp=img, filename="top.png")
-        embed = discord.Embed(title="ТОП-50 по общему времени на сервере")
-        embed.set_image(url="attachment://top.png")
-        await interaction.followup.send(embed=embed, file=file)
+        try:
+            img = draw_top_image(list(rows), title="ТОП-50 по общему времени", size=50, key="total_hours")
+            file = discord.File(fp=img, filename="top.png")
+            embed = discord.Embed(title="ТОП-50 по общему времени на сервере")
+            embed.set_image(url="attachment://top.png")
+            await interaction.followup.send(embed=embed, file=file)
+        except Exception:
+            lines = [f"{i+1}. {row['player_name']} - {row['total_hours']} ч" for i, row in enumerate(rows)]
+            text = "\n".join(lines)
+            await interaction.followup.send(
+                f"Не удалось сгенерировать картинку, вот текстовый топ:\n{text}",
+                ephemeral=True,
+            )
     except Exception as e:
         log_debug(f"[ERROR] /top: {e}")
         await interaction.followup.send("Произошла ошибка при выполнении команды.", ephemeral=True)

--- a/utils/top_image.py
+++ b/utils/top_image.py
@@ -50,7 +50,13 @@ def draw_top_image(rows: List[Dict], title: str, size: int, key: str) -> io.Byte
 
         draw.text((10, y + 10), f"{place}. {name}", font=FONT, fill="black")
         hours_text = f"{hours} ч" if hours != "-" else "-"
-        text_w, _ = draw.textsize(hours_text, font=FONT)
+        try:
+            bbox = draw.textbbox((0, 0), hours_text, font=FONT)
+            text_w = bbox[2] - bbox[0]
+        except AttributeError:
+            # Pillow<10
+            text_w, _ = draw.textsize(hours_text, font=FONT)
+
         draw.text((width - text_w - 10, y + 10), hours_text, font=FONT, fill="black")
 
     buf = io.BytesIO()


### PR DESCRIPTION
## Summary
- fix `draw_top_image` to work with Pillow>=10 (use `textbbox` with fallback)
- provide fallback text ranking in `/top` and `/top7` if image generation fails

## Testing
- `python -m py_compile main.py utils/top_image.py`

------
https://chatgpt.com/codex/tasks/task_e_686c21533310832b93001db07024bfde