### PR TITLE
Rewrite top commands to use embeds

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -70,12 +70,38 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
 
 def build_top_week_embed(top: list[tuple[str, int]], updated_at: datetime) -> discord.Embed:
     """Формирует embed для недельного топа игроков."""
-    lines = [f"{i}. {name} — {hours} часов" for i, (name, hours) in enumerate(top, start=1)]
+
+    lines = [f"{i}. {name} — {hours} ч." for i, (name, hours) in enumerate(top, start=1)]
     description = "\n".join(lines)
+
     embed = discord.Embed(
         title="Топ-10 самых активных игроков недели",
         description=description,
         color=discord.Color.blue(),
     )
     embed.set_footer(text=f"Обновлено: {updated_at.strftime('%d.%m.%Y %H:%M')} по Москве")
+    return embed
+
+
+def build_total_top_embed(top: list[tuple[str, int]]) -> discord.Embed:
+    """Формирует embed для общего топа игроков."""
+
+    lines = [f"{i}. {name} — {hours} ч." for i, (name, hours) in enumerate(top, start=1)]
+
+    embed = discord.Embed(
+        title="Топ-50 по общему времени на сервере",
+        color=discord.Color.orange(),
+    )
+
+    if len(lines) <= 25:
+        # Если строк немного, выводим одним списком
+        embed.description = "\n".join(lines)
+    else:
+        # Иначе делим на две колонки для компактности
+        half = (len(lines) + 1) // 2
+        left = "\n".join(lines[:half])
+        right = "\n".join(lines[half:])
+        embed.add_field(name="\u200b", value=left, inline=True)
+        embed.add_field(name="\u200b", value=right, inline=True)
+
     return embed

--- a/main.py
+++ b/main.py
@@ -9,7 +9,8 @@ import asyncpg
 from bot.updater import ftp_polling_task, api_polling_task
 from utils.logger import log_debug
 from utils.total_time import get_player_total_top
-from utils.top_image import draw_top_image
+from utils.top_week import get_player_top_week
+from bot.discord_ui import build_top_week_embed, build_total_top_embed
 
 
 class MyBot(discord.Client):
@@ -37,25 +38,14 @@ async def cmd_top7(interaction: discord.Interaction):
     log_debug("[/top7] invoked")
     try:
         await interaction.response.defer(thinking=True)
-        rows = await interaction.client.db_pool.fetch(
-            "SELECT player_name, activity_hours FROM player_top_week ORDER BY activity_hours DESC LIMIT 10"
-        )
-        if not rows:
-            await interaction.followup.send("Данных нет", ephemeral=True)
+
+        top, updated_at = await get_player_top_week(interaction.client.db_pool)
+        if not top:
+            await interaction.followup.send("Нет данных для отображения", ephemeral=True)
             return
-        try:
-            img = draw_top_image(list(rows), title="ТОП-10 за неделю", size=10, key="activity_hours")
-            file = discord.File(fp=img, filename="top7.png")
-            embed = discord.Embed(title="ТОП-10 активных игроков за неделю")
-            embed.set_image(url="attachment://top7.png")
-            await interaction.followup.send(embed=embed, file=file)
-        except Exception:
-            lines = [f"{i+1}. {row['player_name']} - {row['activity_hours']} ч" for i, row in enumerate(rows)]
-            text = "\n".join(lines)
-            await interaction.followup.send(
-                f"Не удалось сгенерировать картинку, вот текстовый топ:\n{text}",
-                ephemeral=True,
-            )
+
+        embed = build_top_week_embed(top[:10], updated_at)
+        await interaction.followup.send(embed=embed)
     except Exception as e:
         log_debug(f"[ERROR] /top7: {e}")
         await interaction.followup.send("Произошла ошибка при выполнении команды.", ephemeral=True)
@@ -67,23 +57,15 @@ async def cmd_top(interaction: discord.Interaction):
     log_debug("[/top] invoked")
     try:
         await interaction.response.defer(thinking=True)
+
         rows = await get_player_total_top(interaction.client.db_pool, limit=50)
         if not rows:
-            await interaction.followup.send("Данных нет", ephemeral=True)
+            await interaction.followup.send("Нет данных для отображения", ephemeral=True)
             return
-        try:
-            img = draw_top_image(list(rows), title="ТОП-50 по общему времени", size=50, key="total_hours")
-            file = discord.File(fp=img, filename="top.png")
-            embed = discord.Embed(title="ТОП-50 по общему времени на сервере")
-            embed.set_image(url="attachment://top.png")
-            await interaction.followup.send(embed=embed, file=file)
-        except Exception:
-            lines = [f"{i+1}. {row['player_name']} - {row['total_hours']} ч" for i, row in enumerate(rows)]
-            text = "\n".join(lines)
-            await interaction.followup.send(
-                f"Не удалось сгенерировать картинку, вот текстовый топ:\n{text}",
-                ephemeral=True,
-            )
+
+        top = [(r["player_name"], r["total_hours"]) for r in rows]
+        embed = build_total_top_embed(top)
+        await interaction.followup.send(embed=embed)
     except Exception as e:
         log_debug(f"[ERROR] /top: {e}")
         await interaction.followup.send("Произошла ошибка при выполнении команды.", ephemeral=True)


### PR DESCRIPTION
## Summary
- show top lists in embeds with text instead of images
- add functions for building top embeds
- remove image generation from slash commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d67849b5c832bb4be3e69af004cc6