### PR TITLE
Fix weekly and total activity accumulation

### DIFF
--- a/bot/parsers.py
+++ b/bot/parsers.py
@@ -111,9 +111,8 @@ def parse_players_online(xml_text: str) -> list:
             for player in slots.findall("Player"):
                 if player.get("isUsed") == "true":
                     name = (player.text or "").strip()
-                    if name:
+                    if name and name != "-":
                         players.append(name)
-                        print(f"[DEBUG] Добавлен игрок: {name}")  # Можно убрать после теста
         return players
     except Exception as e:
         log_debug(f"[ERROR] parse_players_online: {e}")

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS player_online_history (
 
 -- Таблица недельного топа
 CREATE TABLE IF NOT EXISTS player_top_week (
-    player_name TEXT NOT NULL,
+    player_name TEXT UNIQUE NOT NULL,
     activity_hours INTEGER NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );

--- a/utils/online_history.py
+++ b/utils/online_history.py
@@ -22,6 +22,8 @@ async def insert_online_players(db_pool: asyncpg.Pool, players: list[str]) -> No
     )
     async with db_pool.acquire() as conn:
         for player in players:
+            if not player or player == "-":
+                continue
             await conn.execute(
                 """
                 INSERT INTO player_online_history (player_name, check_time)

--- a/utils/top_week.py
+++ b/utils/top_week.py
@@ -11,7 +11,6 @@ from utils.helpers import get_moscow_datetime
 async def update_player_top_week(db_pool: asyncpg.Pool) -> None:
     """Пересчитывает топ активных игроков за неделю."""
     threshold = config.weekly_top_threshold
-    top_size = config.weekly_top_size
 
     # Текущее московское время
     now = get_moscow_datetime()
@@ -34,6 +33,7 @@ async def update_player_top_week(db_pool: asyncpg.Pool) -> None:
             SELECT player_name, DATE_TRUNC('hour', check_time) AS hour, COUNT(*) AS cnt
             FROM player_online_history
             WHERE check_time >= $1 AND check_time < $2
+              AND player_name <> '' AND player_name <> '-'
             GROUP BY player_name, hour
             HAVING COUNT(*) >= $3
             """,
@@ -46,25 +46,27 @@ async def update_player_top_week(db_pool: asyncpg.Pool) -> None:
     for r in rows:
         activity[r["player_name"]] = activity.get(r["player_name"], 0) + 1
 
-    top = sorted(activity.items(), key=lambda x: x[1], reverse=True)[:top_size]
-
-    while len(top) < top_size:
-        top.append(("-", 0))
-
-    updated_at = get_moscow_datetime()
-
     async with db_pool.acquire() as conn:
-        await conn.execute("DELETE FROM player_top_week")
-        for name, hours in top:
+        last_update = await conn.fetchval("SELECT MAX(updated_at) FROM player_top_week")
+        if last_update and last_update < start:
+            await conn.execute("DELETE FROM player_top_week")
+
+        for name, hours in activity.items():
             await conn.execute(
                 """
                 INSERT INTO player_top_week (player_name, activity_hours, updated_at)
-                VALUES ($1, $2, $3)
+                VALUES ($1, $2, NOW())
+                ON CONFLICT (player_name) DO UPDATE
+                SET activity_hours = EXCLUDED.activity_hours,
+                    updated_at = NOW()
                 """,
                 name,
                 hours,
-                updated_at,
             )
+
+        await conn.execute(
+            "DELETE FROM player_top_week WHERE player_name = '' OR player_name = '-' OR activity_hours <= 0"
+        )
 
 
 async def get_player_top_week(db_pool: asyncpg.Pool) -> Tuple[List[Tuple[str, int]], datetime]:

--- a/utils/total_time.py
+++ b/utils/total_time.py
@@ -21,43 +21,36 @@ async def update_player_total_time(db_pool: asyncpg.Pool) -> None:
             """
             SELECT player_name, DATE_TRUNC('hour', check_time) AS hour, COUNT(*) AS cnt
             FROM player_online_history
+            WHERE player_name <> '' AND player_name <> '-'
             GROUP BY player_name, hour
             HAVING COUNT(*) >= 3
             """
         )
 
-        # Текущие значения общих часов в базе
-        existing_rows = await conn.fetch(
-            "SELECT player_name, total_hours FROM player_total_time"
-        )
+
 
     # Считаем зачтённые часы по данным истории
     hours_by_player: Dict[str, int] = defaultdict(int)
     for row in hourly_rows:
         hours_by_player[row["player_name"]] += 1
 
-    current_totals: Dict[str, int] = {
-        row["player_name"]: row["total_hours"] for row in existing_rows
-    }
-
-    # Вносим обновления только если появилось новое время
     async with db_pool.acquire() as conn:
         for name, total in hours_by_player.items():
-            increment = total - current_totals.get(name, 0)
-            if increment <= 0:
-                continue
-
             await conn.execute(
                 """
                 INSERT INTO player_total_time (player_name, total_hours, updated_at)
                 VALUES ($1, $2, NOW())
                 ON CONFLICT (player_name) DO UPDATE
-                SET total_hours = player_total_time.total_hours + $2,
+                SET total_hours = EXCLUDED.total_hours,
                     updated_at = NOW()
                 """,
                 name,
-                increment,
+                total,
             )
+
+        await conn.execute(
+            "DELETE FROM player_total_time WHERE player_name = '' OR player_name = '-' OR total_hours <= 0"
+        )
 
 
 async def get_player_total_top(db_pool: asyncpg.Pool, limit: int = 50):


### PR DESCRIPTION
## Summary
- ensure player_top_week has unique player names
- skip placeholder names when parsing and logging
- ignore garbage entries on online player insert
- rewrite weekly/top time updates with proper UPSERT logic

## Testing
- `python -m compileall -q -f bot utils`

------
https://chatgpt.com/codex/tasks/task_e_686df762f95c832b9cf50e4a9b17aecb