### PR TITLE
Fix online history duplicates

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,6 +4,10 @@ CREATE TABLE IF NOT EXISTS player_online_history (
     check_time TIMESTAMP NOT NULL
 );
 
+-- Гарантируем уникальность записи игрока в конкретный момент времени
+CREATE UNIQUE INDEX IF NOT EXISTS idx_player_online_history_unique
+    ON player_online_history (player_name, check_time);
+
 -- Таблица недельного топа
 CREATE TABLE IF NOT EXISTS player_top_week (
     player_name TEXT UNIQUE NOT NULL,

--- a/utils/online_history.py
+++ b/utils/online_history.py
@@ -28,7 +28,7 @@ async def insert_online_players(db_pool: asyncpg.Pool, players: list[str]) -> No
                 """
                 INSERT INTO player_online_history (player_name, check_time)
                 VALUES ($1, $2)
-                ON CONFLICT DO NOTHING
+                ON CONFLICT (player_name, check_time) DO NOTHING
                 """,
                 player,
                 slot_start,


### PR DESCRIPTION
## Summary
- add unique index on `(player_name, check_time)`
- use `ON CONFLICT` with these columns when saving online players

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e81fcd378832b99586cd5ba70a9a7