### PR TITLE
Add cleanup task for online history

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -130,9 +130,25 @@ async def save_online_history_task(bot: discord.Client):
                     if wait_seconds <= 0:
                         wait_seconds = 1
                     log_debug(f"[ONLINE] Не время среза, ждём {wait_seconds} секунд")
-                    await asyncio.sleep(wait_seconds)
+                await asyncio.sleep(wait_seconds)
             except Exception as e:
                 log_debug(f"[TASK] save_online_history_task error: {e}")
                 await asyncio.sleep(5)
+
+
+async def cleanup_old_online_history_task(bot: discord.Client):
+    """Удаляет записи старше 30 дней из player_online_history."""
+    log_debug("[TASK] Запущен cleanup_old_online_history_task")
+    await bot.wait_until_ready()
+    while not bot.is_closed():
+        try:
+            log_debug("[DB] Удаляем старые записи из player_online_history")
+            await bot.db_pool.execute(
+                "DELETE FROM player_online_history WHERE check_time < NOW() - INTERVAL '30 days'"
+            )
+            await asyncio.sleep(86400)
+        except Exception as e:
+            log_debug(f"[TASK] cleanup_old_online_history_task error: {e}")
+            await asyncio.sleep(5)
 
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,12 @@ from discord import app_commands
 
 from config.config import config
 import asyncpg
-from bot.updater import ftp_polling_task, api_polling_task, save_online_history_task
+from bot.updater import (
+    ftp_polling_task,
+    api_polling_task,
+    save_online_history_task,
+    cleanup_old_online_history_task,
+)
 from utils.logger import log_debug
 
 
@@ -31,6 +36,7 @@ class MyBot(discord.Client):
         asyncio.create_task(api_polling_task())
         asyncio.create_task(ftp_polling_task(self))
         asyncio.create_task(save_online_history_task(self))
+        asyncio.create_task(cleanup_old_online_history_task(self))
         log_debug("[SETUP] Background tasks started")
 
         await self.tree.sync()


### PR DESCRIPTION
## Summary
- regularly purge `player_online_history` records older than 30 days
- start the cleanup task when the bot starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea1a14b30832bb0c29d1de7086e87