### PR TITLE
Add daily player count graph

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -11,7 +11,7 @@ from ftp.fetcher import fetch_file
 from .fetchers import fetch_stats_xml, fetch_api_file, fetch_dedicated_server_stats
 from .parsers import parse_all, parse_players_online
 from .discord_ui import build_embed
-from utils.online_graph import draw_online_graph
+from utils.online_daily_graph import save_daily_online_graph
 from utils.logger import log_debug
 
 async def ftp_polling_task(bot: discord.Client):
@@ -73,27 +73,22 @@ async def ftp_polling_task(bot: discord.Client):
                 data["server_status"] = server_status
                 embed = build_embed(data)
 
-                # Получаем почасовой онлайн за текущий день
+                # Получаем суточную статистику количества игроков
                 rows = await bot.db_pool.fetch(
                     """
-                    SELECT player_name, hour, COUNT(*) AS count
+                    SELECT hour, COUNT(*) AS count
                     FROM player_online_history
                     WHERE date = CURRENT_DATE
-                    GROUP BY player_name, hour
-                    ORDER BY player_name, hour
+                    GROUP BY hour
                     """
                 )
 
-                online_data = {}
+                hourly_counts = [0] * 24
                 for row in rows:
-                    name = row["player_name"]
-                    hour = row["hour"]
-                    if name not in online_data:
-                        online_data[name] = [0] * 24
-                    online_data[name][hour] = row["count"]
+                    hourly_counts[int(row["hour"])] = row["count"]
 
-                image_buf = draw_online_graph(online_data)
-                embed.set_image(url="attachment://online_day.png")
+                image_path = save_daily_online_graph(hourly_counts)
+                embed.set_image(url="attachment://online_daily_graph.png")
 
                 async for msg in channel.history(limit=None):
                     try:
@@ -104,7 +99,7 @@ async def ftp_polling_task(bot: discord.Client):
                 log_debug("[Discord] Отправляем сообщение")
                 await channel.send(
                     embed=embed,
-                    files=[discord.File(fp=image_buf, filename="online_day.png")],
+                    files=[discord.File(image_path, filename="online_daily_graph.png")],
                 )
                 log_debug("[Discord] ✅ Embed успешно отправлен.")
 

--- a/utils/online_daily_graph.py
+++ b/utils/online_daily_graph.py
@@ -1,0 +1,39 @@
+"""Генерация суточного графика количества игроков."""
+
+from typing import List
+import os
+import matplotlib.pyplot as plt
+
+from utils.helpers import get_moscow_datetime
+
+
+def save_daily_online_graph(counts: List[int]) -> str:
+    """Сохраняет PNG-график количества игроков по часам за сегодня.
+
+    Args:
+        counts: Список из 24 значений, по одному на каждый час.
+    Returns:
+        Путь к сохранённому изображению.
+    """
+    now_hour = get_moscow_datetime().hour
+    hours = list(range(now_hour + 1, 24)) + list(range(0, now_hour + 1))
+    rotated = counts[now_hour + 1 :] + counts[: now_hour + 1]
+
+    plt.figure(figsize=(10, 3))
+    plt.bar(range(24), rotated, color="tab:blue")
+    plt.xticks(range(24), hours)
+    plt.xlabel("Час")
+    plt.ylabel("Игроки")
+    plt.title("Количество игроков по часам (сегодня)")
+
+    max_val = max(rotated) if rotated else 0
+    tick_count = max(max_val + 1, 6)
+    plt.yticks(range(tick_count))
+    plt.tight_layout()
+
+    os.makedirs("output", exist_ok=True)
+    file_path = "output/online_daily_graph.png"
+    plt.savefig(file_path)
+    plt.close()
+    return file_path
+


### PR DESCRIPTION
## Summary
- generate player count for each hour of the current day
- plot graph with current hour on the right side
- post graph as attachment in the bot's update message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686eace44b9c832bb8f4b71715d20ee3