### PR TITLE
Count unique players in hourly stats

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -77,7 +77,7 @@ async def ftp_polling_task(bot: discord.Client):
                 # Получаем суточную статистику количества игроков
                 rows = await bot.db_pool.fetch(
                     """
-                    SELECT hour, COUNT(*) AS count
+                    SELECT hour, COUNT(DISTINCT player_name) AS count
                     FROM player_online_history
                     WHERE date = CURRENT_DATE
                     GROUP BY hour


### PR DESCRIPTION
## Summary
- count unique players per hour when building the online graph

## Testing
- `python -m py_compile bot/updater.py`


------
https://chatgpt.com/codex/tasks/task_e_686eb322ac14832b8e5149aa3b665462