### PR TITLE
Implement /online_month command fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from discord import app_commands
 
 from config.config import (
     config,
-    MONTHLY_GRAPH_OUTPUT_PATH,
     MONTHLY_GRAPH_TITLE,
 )
 import asyncpg
@@ -26,20 +25,6 @@ class MyBot(discord.Client):
         super().__init__(intents=intents)
         self.tree = app_commands.CommandTree(self)
 
-    @app_commands.command(name="online_month", description="График активности за 30 дней")
-    async def online_month(self, interaction: discord.Interaction) -> None:
-        """Отправляет график активности игроков за последний месяц."""
-        await interaction.response.defer()
-        try:
-            path = await generate_monthly_online_graph(self.db_pool)
-            embed = discord.Embed(title=MONTHLY_GRAPH_TITLE)
-            embed.set_image(url=f"attachment://{os.path.basename(MONTHLY_GRAPH_OUTPUT_PATH)}")
-            await interaction.followup.send(
-                embed=embed,
-                file=discord.File(path, filename=os.path.basename(MONTHLY_GRAPH_OUTPUT_PATH)),
-            )
-        except Exception as e:
-            await interaction.followup.send(f"Ошибка: {e}", ephemeral=True)
 
     async def _ensure_indexes(self) -> None:
         """Creates required database indexes if they do not exist."""
@@ -60,8 +45,6 @@ class MyBot(discord.Client):
         asyncio.create_task(cleanup_old_online_history_task(self))
         log_debug("[SETUP] Background tasks started")
 
-        self.tree.add_command(self.online_month)
-
         await self.tree.sync()
         log_debug("[Slash] Команды синхронизированы")
 
@@ -77,6 +60,28 @@ if __name__ == "__main__":
     intents.guilds = True
 
     bot = MyBot(intents=intents)
+    tree = bot.tree
+
+    @tree.command(name="online_month", description="График онлайна за последние 30 дней")
+    async def online_month_command(interaction: discord.Interaction):
+        await interaction.response.defer()
+        try:
+            path = await generate_monthly_online_graph(interaction.client.db_pool)
+            if not path:
+                await interaction.followup.send("Нет данных за последний месяц.")
+                return
+            embed = discord.Embed(title=MONTHLY_GRAPH_TITLE)
+            embed.set_image(url=f"attachment://{os.path.basename(path)}")
+            await interaction.followup.send(
+                embed=embed,
+                file=discord.File(path, filename=os.path.basename(path)),
+            )
+        except Exception as e:
+            log_debug(f"[CMD] online_month error: {e}")
+            await interaction.followup.send(
+                "Ошибка при генерации графика.", ephemeral=True
+            )
+
     log_debug("Запускаем Discord-бота")
     try:
         bot.run(config.discord_token)


### PR DESCRIPTION
## Summary
- improve monthly online graph generation
- add slash command `online_month` in main

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb9fe8f74832b8f465259aae9d9f8