### PR TITLE
Implement /online_month command

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -34,3 +34,12 @@ MONTHLY_GRAPH_OUTPUT_PATH = "output/monthly_online_graph.png"
 # Заголовок для месячного графика онлайна
 MONTHLY_GRAPH_TITLE = "Онлайн игроков за последние 30 дней"
 
+# Количество дней для команды /online_month
+ONLINE_MONTH_DAYS = 30
+
+# Путь для сохранения графика из /online_month
+ONLINE_MONTH_GRAPH_PATH = "output/online_month_graph.png"
+
+# Заголовок для графика из /online_month
+ONLINE_MONTH_GRAPH_TITLE = "Онлайн по дням (последние 30 дней)"
+

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from discord import app_commands
 
 from config.config import (
     config,
-    MONTHLY_GRAPH_TITLE,
+    ONLINE_MONTH_GRAPH_TITLE,
 )
 import asyncpg
 from bot.updater import (
@@ -16,7 +16,7 @@ from bot.updater import (
     save_online_history_task,
     cleanup_old_online_history_task,
 )
-from utils.monthly_online_graph import generate_monthly_online_graph
+from utils.online_month_graph import generate_online_month_graph
 from utils.logger import log_debug
 
 
@@ -62,15 +62,15 @@ if __name__ == "__main__":
     bot = MyBot(intents=intents)
     tree = bot.tree
 
-    @tree.command(name="online_month", description="График онлайна за последние 30 дней")
+    @tree.command(name="online_month", description="График онлайна по дням за последние 30 дней")
     async def online_month_command(interaction: discord.Interaction):
         await interaction.response.defer()
         try:
-            path = await generate_monthly_online_graph(interaction.client.db_pool)
+            path = await generate_online_month_graph(interaction.client.db_pool)
             if not path:
                 await interaction.followup.send("Нет данных за последний месяц.")
                 return
-            embed = discord.Embed(title=MONTHLY_GRAPH_TITLE)
+            embed = discord.Embed(title=ONLINE_MONTH_GRAPH_TITLE)
             embed.set_image(url=f"attachment://{os.path.basename(path)}")
             await interaction.followup.send(
                 embed=embed,

--- a/utils/online_month_graph.py
+++ b/utils/online_month_graph.py
@@ -1,0 +1,79 @@
+"""Генерация графика уникальных игроков по дням за последние N дней."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+
+import matplotlib.pyplot as plt
+
+from config.config import (
+    ONLINE_MONTH_DAYS,
+    ONLINE_MONTH_GRAPH_PATH,
+    ONLINE_MONTH_GRAPH_TITLE,
+)
+from utils.logger import log_debug
+
+
+async def generate_online_month_graph(db_pool) -> Optional[str]:
+    """Создаёт PNG-график уникальных игроков по дням.
+
+    Args:
+        db_pool: Пул подключений к базе данных.
+
+    Returns:
+        Путь к сохранённому изображению или ``None`` при отсутствии данных.
+    """
+
+    try:
+        rows = await db_pool.fetch(
+            f"""
+            SELECT DATE(check_time) AS day,
+                   COUNT(DISTINCT player_name) AS count
+            FROM player_online_history
+            WHERE check_time >= NOW() - INTERVAL '{ONLINE_MONTH_DAYS} days'
+            GROUP BY day
+            ORDER BY day
+            """
+        )
+    except Exception as e:
+        log_debug(f"[DB] Error fetching online month data: {e}")
+        raise
+
+    if not rows:
+        return None
+
+    counts = {row["day"]: row["count"] for row in rows}
+
+    today = datetime.utcnow().date()
+    start_date = today - timedelta(days=ONLINE_MONTH_DAYS - 1)
+    dates = [start_date + timedelta(days=i) for i in range(ONLINE_MONTH_DAYS)]
+    values = [counts.get(d, 0) for d in dates]
+
+    try:
+        plt.figure(figsize=(10, 4))
+        plt.plot(range(len(values)), values, marker="o", color="tab:blue")
+
+        tick_labels = [d.strftime("%d.%m") for d in dates]
+        plt.xticks(ticks=range(len(dates)), labels=tick_labels, rotation=45)
+        plt.xlabel("Дата")
+        plt.ylabel("Уникальные игроки")
+        plt.title(ONLINE_MONTH_GRAPH_TITLE)
+
+        max_val = max(values) if values else 0
+        tick_count = max(max_val + 1, 6)
+        plt.yticks(range(tick_count))
+
+        plt.grid(axis="both", linestyle="--", alpha=0.5)
+        plt.tight_layout()
+
+        output_path = os.path.join(os.getcwd(), ONLINE_MONTH_GRAPH_PATH)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        plt.savefig(output_path)
+        plt.close()
+
+        return output_path
+    except Exception as e:
+        log_debug(f"[GRAPH] Error building online month graph: {e}")
+        raise


### PR DESCRIPTION
## Summary
- add settings for /online_month graph
- implement generator to plot daily unique players
- wire up /online_month command to use new graph

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ebe19f5c8832bb65e07103922b93b