### PR TITLE
Rotate monthly graph tick labels

### DIFF
--- a/utils/monthly_online_graph.py
+++ b/utils/monthly_online_graph.py
@@ -72,7 +72,12 @@ async def generate_monthly_online_graph(db_pool) -> Optional[str]:
 
     tick_positions = [i * 24 for i in range(len(dates))]
     tick_labels = [d.strftime("%d.%m") for d in dates]
-    plt.xticks(ticks=tick_positions, labels=tick_labels, rotation=45)
+    plt.xticks(
+        ticks=tick_positions,
+        labels=tick_labels,
+        rotation=90,
+        ha="center",
+    )
     plt.xlabel("Дата")
     plt.ylabel("Игроки")
     plt.title(MONTHLY_GRAPH_TITLE)

--- a/utils/online_month_graph.py
+++ b/utils/online_month_graph.py
@@ -22,7 +22,7 @@ def save_monthly_online_graph(dates: List[str], counts: List[int]) -> str:
     plt.figure(figsize=(10, 4))
     plt.bar(range(len(counts)), counts, color="tab:blue")
 
-    plt.xticks(ticks=range(len(dates)), labels=dates)
+    plt.xticks(ticks=range(len(dates)), labels=dates, rotation=90, ha="center")
     plt.xlim(-0.5, len(dates) - 0.5)
 
     plt.xlabel("Дата")


### PR DESCRIPTION
## Summary
- show monthly x-axis dates vertically for better readability

## Testing
- `python -m py_compile utils/online_month_graph.py utils/monthly_online_graph.py`

------
https://chatgpt.com/codex/tasks/task_e_686ec4625c5c832b82324bb19f75eaf6