### PR TITLE
Fix daily graph timezone filter

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -13,6 +13,7 @@ from .fetchers import fetch_stats_xml, fetch_api_file, fetch_dedicated_server_st
 from .parsers import parse_all, parse_players_online
 from .discord_ui import build_embed
 from utils.online_daily_graph import save_daily_online_graph
+from utils.helpers import get_moscow_datetime
 from utils.logger import log_debug
 
 async def ftp_polling_task(bot: discord.Client):
@@ -75,14 +76,29 @@ async def ftp_polling_task(bot: discord.Client):
                 embed = build_embed(data)
 
                 # Получаем суточную статистику количества игроков
+                moscow_date = get_moscow_datetime().date()
                 rows = await bot.db_pool.fetch(
                     """
                     SELECT hour, COUNT(DISTINCT player_name) AS count
                     FROM player_online_history
-                    WHERE date = CURRENT_DATE
+                    WHERE date = $1
                     GROUP BY hour
-                    """
+                    """,
+                    moscow_date,
                 )
+
+                # Если за сегодня нет данных, берем статистику за вчера
+                if not rows:
+                    prev_date = moscow_date - timedelta(days=1)
+                    rows = await bot.db_pool.fetch(
+                        """
+                        SELECT hour, COUNT(DISTINCT player_name) AS count
+                        FROM player_online_history
+                        WHERE date = $1
+                        GROUP BY hour
+                        """,
+                        prev_date,
+                    )
 
                 hourly_counts = [0] * 24
                 for row in rows:


### PR DESCRIPTION
## Summary
- fix timezone filter for daily player count
- show yesterday's data if today's is empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f329eb0b4832baae81a84db3647c1