### PR TITLE
Remove unused monthly graph constants

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -28,11 +28,6 @@ cleanup_history_days = 30
 # Интервал запуска задачи очистки (в секундах)
 cleanup_task_interval_seconds = 86400
 
-# Путь для сохранения месячного графика онлайна
-MONTHLY_GRAPH_OUTPUT_PATH = "output/monthly_online_graph.png"
-
-# Заголовок для месячного графика онлайна
-MONTHLY_GRAPH_TITLE = "Онлайн игроков за последние 30 дней"
 
 # Количество дней для команды /online_month
 ONLINE_MONTH_DAYS = 30

--- a/utils/monthly_online_graph.py
+++ b/utils/monthly_online_graph.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 import matplotlib.pyplot as plt
 
-from config.config import MONTHLY_GRAPH_TITLE
+MONTHLY_GRAPH_TITLE = "Онлайн игроков за последние 30 дней"
 from utils.logger import log_debug
 
 


### PR DESCRIPTION
## Summary
- delete `MONTHLY_GRAPH_OUTPUT_PATH` and `MONTHLY_GRAPH_TITLE` from `config.py`
- localize the title constant in `monthly_online_graph.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f42c71330832b97fabdcf905aced7