### PR TITLE
Refactor daily online graph generation

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -42,6 +42,7 @@ ONLINE_MONTH_DAYS = 30
 ONLINE_MONTH_GRAPH_FILENAME = "online_month_graph.png"
 ONLINE_DAILY_GRAPH_FILENAME = "online_daily_graph.png"
 ONLINE_MONTH_GRAPH_TITLE = "Онлайн по дням (последние 30 дней)"
+ONLINE_DAILY_GRAPH_TITLE = "Количество игроков по часам (сегодня)"
 
 ONLINE_MONTH_GRAPH_PATH = config.output_dir / ONLINE_MONTH_GRAPH_FILENAME
 ONLINE_DAILY_GRAPH_PATH = config.output_dir / ONLINE_DAILY_GRAPH_FILENAME


### PR DESCRIPTION
## Summary
- add ONLINE_DAILY_GRAPH_TITLE constant
- gather hourly player counts using new helper
- draw graph with config title
- use config filename in ftp polling task

## Testing
- `python -m py_compile config/config.py utils/online_daily_graph.py bot/updater.py`

------
https://chatgpt.com/codex/tasks/task_e_686f6e6431d4832bb3cf9993cc3dc7c3