### PR TITLE
Implement weekly online activity top

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -46,3 +46,9 @@ ONLINE_DAILY_GRAPH_TITLE = "Количество игроков по часам 
 
 ONLINE_MONTH_GRAPH_PATH = config.output_dir / ONLINE_MONTH_GRAPH_FILENAME
 ONLINE_DAILY_GRAPH_PATH = config.output_dir / ONLINE_DAILY_GRAPH_FILENAME
+
+# Weekly top settings
+WEEKLY_TOP_LIMIT = int(os.getenv("WEEKLY_TOP_LIMIT", 7))
+WEEKLY_TOP_MAX = int(os.getenv("WEEKLY_TOP_MAX", 10))
+WEEKLY_TOP_WEEKDAY = int(os.getenv("WEEKLY_TOP_WEEKDAY", 0))
+WEEKLY_TOP_HOUR = int(os.getenv("WEEKLY_TOP_HOUR", 12))

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from bot.updater import (
     cleanup_old_online_history_task,
 )
 from utils.online_month_graph import generate_online_month_graph
+from utils.weekly_top import generate_weekly_top
 from utils.logger import log_debug
 
 
@@ -50,6 +51,18 @@ class MyBot(discord.Client):
     async def on_ready(self) -> None:
         """Log successful authorization."""
         log_debug(f"Discord-бот авторизован как {self.user}")
+
+    async def on_message(self, message: discord.Message) -> None:
+        """Обрабатывает текстовые команды."""
+        if message.author.bot:
+            return
+        if message.content.strip() == "!top7week":
+            try:
+                text = await generate_weekly_top(self.db_pool)
+                await message.channel.send(text)
+            except Exception as e:
+                log_debug(f"[CMD] top7week error: {e}")
+                await message.channel.send("Ошибка при получении топа.")
 
 
 if __name__ == "__main__":

--- a/utils/weekly_top.py
+++ b/utils/weekly_top.py
@@ -1,0 +1,68 @@
+"""Логика для подсчёта недельного топа игроков."""
+
+from datetime import datetime, timedelta
+from typing import List
+
+from config.config import (
+    WEEKLY_TOP_LIMIT,
+    WEEKLY_TOP_MAX,
+    WEEKLY_TOP_WEEKDAY,
+    WEEKLY_TOP_HOUR,
+)
+from utils.helpers import get_moscow_datetime
+from utils.logger import log_debug
+
+
+def _get_week_bounds() -> tuple[datetime, datetime]:
+    """Возвращает начало и конец недельного периода."""
+    now = get_moscow_datetime()
+    start = now.replace(
+        hour=WEEKLY_TOP_HOUR,
+        minute=0,
+        second=0,
+        microsecond=0,
+    )
+    days_since = (now.weekday() - WEEKLY_TOP_WEEKDAY) % 7
+    start -= timedelta(days=days_since)
+    if now < start:
+        start -= timedelta(days=7)
+    end = start + timedelta(days=7)
+    return start, end
+
+
+async def generate_weekly_top(db_pool) -> str:
+    """Формирует текстовое сообщение с топом игроков за неделю."""
+    start, end = _get_week_bounds()
+    log_debug(f"[TOP] Период с {start} по {end}")
+    try:
+        rows = await db_pool.fetch(
+            """
+            SELECT player_name, COUNT(*) AS hours
+            FROM (
+                SELECT player_name, date, hour
+                FROM player_online_history
+                WHERE check_time >= $1 AND check_time < $2
+                GROUP BY player_name, date, hour
+                HAVING COUNT(*) >= 3
+            ) AS t
+            GROUP BY player_name
+            ORDER BY hours DESC, player_name
+            LIMIT $3
+            """,
+            start,
+            end,
+            WEEKLY_TOP_MAX,
+        )
+    except Exception as e:
+        log_debug(f"[DB] Error fetching weekly top: {e}")
+        raise
+
+    if not rows:
+        return "Нет данных за неделю."
+
+    limit = min(WEEKLY_TOP_LIMIT, len(rows))
+    lines: List[str] = [f"\U0001F4CA ТОП {limit} игроков за неделю:"]
+    for idx, row in enumerate(rows[:limit], start=1):
+        lines.append(f"{idx}. {row['player_name']} — {row['hours']} ч")
+
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- add configurable weekly top settings
- implement weekly top calculation
- respond to `!top7week` command

## Testing
- `python -m py_compile config/config.py utils/weekly_top.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6870b14e7f04832bbbe3dfc10c284407