### PR TITLE
Fix slash command registration

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ class MyBot(discord.Client):
         asyncio.create_task(cleanup_old_online_history_task(self))
         log_debug("[SETUP] Background tasks started")
 
+        self.tree.add_command(top7week_command)
         await self.tree.sync()
         log_debug("[Slash] Команды синхронизированы")
 
@@ -87,7 +88,7 @@ if __name__ == "__main__":
                 "Ошибка при генерации графика.", ephemeral=True
             )
 
-    @tree.command(name="top7week", description="ТОП 7 игроков за неделю")
+    @app_commands.command(name="top7week", description="ТОП 7 игроков за неделю")
     async def top7week_command(interaction: discord.Interaction) -> None:
         """Handle `/top7week` command."""
         await interaction.response.defer()


### PR DESCRIPTION
## Summary
- register `/top7week` as an `app_commands` command
- add command to command tree during `setup_hook`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6870bce0addc832baf35b77e567f8741