### PR TITLE
Modularize Discord slash commands

### DIFF
--- a/commands/online_month.py
+++ b/commands/online_month.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+
+import discord
+from discord import app_commands
+
+from config.config import ONLINE_MONTH_GRAPH_TITLE
+from utils.online_month_graph import generate_online_month_graph
+from utils.logger import log_debug
+
+
+def setup(tree: app_commands.CommandTree) -> None:
+    @tree.command(
+        name="online_month",
+        description="График онлайна по дням за последние 30 дней",
+    )
+    async def online_month_command(interaction: discord.Interaction) -> None:
+        await interaction.response.defer()
+        try:
+            path = await generate_online_month_graph(interaction.client.db_pool)
+            if not path:
+                await interaction.followup.send("Нет данных за последний месяц.")
+                return
+            embed = discord.Embed(title=ONLINE_MONTH_GRAPH_TITLE)
+            embed.set_image(url=f"attachment://{os.path.basename(path)}")
+            await interaction.followup.send(
+                embed=embed,
+                file=discord.File(path, filename=os.path.basename(path)),
+            )
+        except Exception as e:
+            log_debug(f"[CMD] online_month error: {e}")
+            await interaction.followup.send(
+                "Ошибка при генерации графика.", ephemeral=True
+            )
+
+    log_debug("[Slash] Команда /online_month зарегистрирована")
+

--- a/commands/top7week.py
+++ b/commands/top7week.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+
+from utils.weekly_top import generate_weekly_top
+from utils.logger import log_debug
+
+
+def setup(tree: app_commands.CommandTree) -> None:
+    @tree.command(name="top7week", description="Топ 7 игроков за неделю по часам")
+    async def top7week_command(interaction: discord.Interaction) -> None:
+        await interaction.response.defer()
+        try:
+            text = await generate_weekly_top(interaction.client.db_pool)
+            await interaction.followup.send(text)
+        except Exception as e:
+            log_debug(f"[CMD] top7week error: {e}")
+            await interaction.followup.send(
+                "Ошибка при получении топа.", ephemeral=True
+            )
+
+    log_debug("[Slash] Команда /top7week зарегистрирована")
+

--- a/main.py
+++ b/main.py
@@ -1,23 +1,23 @@
 """Entry point for launching the Discord bot."""
 
 import asyncio
-import os
 
 import asyncpg
 import discord
 from discord import app_commands
 
-from config.config import config, ONLINE_MONTH_GRAPH_TITLE
+from config.config import config
 from bot.updater import (
     ftp_polling_task,
     api_polling_task,
     save_online_history_task,
     cleanup_old_online_history_task,
 )
-from utils.online_month_graph import generate_online_month_graph
-from utils.weekly_top import generate_weekly_top
+
 from utils.logger import log_debug
 from commands.top7lastweek import setup as setup_top7lastweek
+from commands.top7week import setup as setup_top7week
+from commands.online_month import setup as setup_online_month
 
 
 class MyBot(discord.Client):
@@ -46,25 +46,7 @@ class MyBot(discord.Client):
         asyncio.create_task(cleanup_old_online_history_task(self))
         log_debug("[SETUP] Background tasks started")
 
-        @self.tree.command(
-            name="top7week",
-            description="Топ 7 игроков за неделю по часам",
-        )
-        async def top7week_command(
-            interaction: discord.Interaction,
-        ) -> None:
-            """Handle `/top7week` command."""
-            await interaction.response.defer()
-            try:
-                text = await generate_weekly_top(interaction.client.db_pool)
-                await interaction.followup.send(text)
-            except Exception as e:
-                log_debug(f"[CMD] top7week error: {e}")
-                await interaction.followup.send(
-                    "Ошибка при получении топа.", ephemeral=True
-                )
-
-        log_debug("[Slash] Команда /top7week зарегистрирована")
+        setup_top7week(self.tree)
 
         setup_top7lastweek(self.tree)
         await self.tree.sync()
@@ -89,26 +71,7 @@ if __name__ == "__main__":
     bot = MyBot(intents=intents)
     tree = bot.tree
 
-    @tree.command(name="online_month", description="График онлайна по дням за последние 30 дней")
-    async def online_month_command(interaction: discord.Interaction) -> None:
-        """Handle `/online_month` command."""
-        await interaction.response.defer()
-        try:
-            path = await generate_online_month_graph(interaction.client.db_pool)
-            if not path:
-                await interaction.followup.send("Нет данных за последний месяц.")
-                return
-            embed = discord.Embed(title=ONLINE_MONTH_GRAPH_TITLE)
-            embed.set_image(url=f"attachment://{os.path.basename(path)}")
-            await interaction.followup.send(
-                embed=embed,
-                file=discord.File(path, filename=os.path.basename(path)),
-            )
-        except Exception as e:
-            log_debug(f"[CMD] online_month error: {e}")
-            await interaction.followup.send(
-                "Ошибка при генерации графика.", ephemeral=True
-            )
+    setup_online_month(tree)
 
     log_debug("Запускаем Discord-бота")
     try:


### PR DESCRIPTION
## Summary
- move `/online_month` and `/top7week` commands to `commands/`
- import new command setup helpers in `main.py`
- register commands via helper functions in `setup_hook` and `__main__`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68714df46bd8832ba126085c8c89d51f