### PR TITLE
Implement total play time updater

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from bot.updater import (
     save_online_history_task,
     cleanup_old_online_history_task,
 )
+from utils.total_time_updater import total_time_update_task
 
 from utils.logger import log_debug
 from commands.top7lastweek import setup as setup_top7lastweek
@@ -44,6 +45,7 @@ class MyBot(discord.Client):
         asyncio.create_task(ftp_polling_task(self))
         asyncio.create_task(save_online_history_task(self))
         asyncio.create_task(cleanup_old_online_history_task(self))
+        asyncio.create_task(total_time_update_task(self))
         log_debug("[SETUP] Background tasks started")
 
         setup_top7week(self.tree)

--- a/utils/total_time_updater.py
+++ b/utils/total_time_updater.py
@@ -1,0 +1,92 @@
+"""Utilities for updating total play time of players."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List, Tuple
+
+from asyncpg import Pool
+
+from utils.logger import log_debug
+
+
+async def _fetch_total_hours(
+    db_pool: Pool,
+    *,
+    history_table: str = "player_online_history",
+) -> List[Tuple[str, int]]:
+    """Return total active hours for each player from history."""
+    query = f"""
+        SELECT player_name, COUNT(*) AS hours
+        FROM (
+            SELECT player_name, date, hour
+            FROM {history_table}
+            GROUP BY player_name, date, hour
+            HAVING COUNT(*) >= 3
+        ) AS t
+        GROUP BY player_name
+    """
+    try:
+        rows = await db_pool.fetch(query)
+    except Exception as e:
+        log_debug(f"[DB] Error fetching total hours: {e}")
+        raise
+
+    return [(r["player_name"], int(r["hours"])) for r in rows]
+
+
+async def update_total_time(
+    db_pool: Pool,
+    *,
+    history_table: str = "player_online_history",
+    total_table: str = "player_total_time",
+) -> None:
+    """Calculate total hours and update the total time table."""
+    rows = await _fetch_total_hours(db_pool, history_table=history_table)
+
+    if not rows:
+        log_debug("[TOTAL] Нет данных для обновления")
+        return
+
+    try:
+        async with db_pool.acquire() as conn:
+            async with conn.transaction():
+                for name, hours in rows:
+                    await conn.execute(
+                        f"""
+                        INSERT INTO {total_table} (player_name, total_hours, updated_at)
+                        VALUES ($1, $2, NOW())
+                        ON CONFLICT (player_name) DO UPDATE
+                        SET total_hours = EXCLUDED.total_hours,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        name,
+                        hours,
+                    )
+        log_debug(f"[TOTAL] Обновлено {len(rows)} записей")
+    except Exception as e:
+        log_debug(f"[DB] Error updating total time: {e}")
+        raise
+
+
+async def total_time_update_task(
+    bot,
+    *,
+    interval_seconds: int = 3600,
+    history_table: str = "player_online_history",
+    total_table: str = "player_total_time",
+) -> None:
+    """Background task to periodically update player total time."""
+    log_debug("[TASK] Запущен total_time_update_task")
+    await bot.wait_until_ready()
+    while not bot.is_closed():
+        try:
+            await update_total_time(
+                bot.db_pool,
+                history_table=history_table,
+                total_table=total_table,
+            )
+            await asyncio.sleep(interval_seconds)
+        except Exception as e:
+            log_debug(f"[TASK] total_time_update_task error: {e}")
+            await asyncio.sleep(5)


### PR DESCRIPTION
## Summary
- add `utils.total_time_updater` for calculating total hours from `player_online_history`
- start the new `total_time_update_task` with the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687152aac2bc832ba08ff49516ccd3da