### PR TITLE
Improve reliability of background tasks

### DIFF
--- a/utils/total_time_updater.py
+++ b/utils/total_time_updater.py
@@ -87,6 +87,9 @@ async def total_time_update_task(
                 total_table=total_table,
             )
             await asyncio.sleep(interval_seconds)
+        except asyncio.CancelledError:
+            log_debug("[TASK] total_time_update_task cancelled")
+            break
         except Exception as e:
             log_debug(f"[TASK] total_time_update_task error: {e}")
             await asyncio.sleep(5)

--- a/utils/weekly_archiver.py
+++ b/utils/weekly_archiver.py
@@ -126,6 +126,9 @@ async def weekly_top_archive_task(
                 limit=limit,
                 max_fetch=max_fetch,
             )
+        except asyncio.CancelledError:
+            log_debug("[TASK] weekly_top_archive_task cancelled")
+            break
         except Exception as e:
             log_debug(f"[TASK] weekly_top_archive_task error: {e}")
             await asyncio.sleep(5)


### PR DESCRIPTION
## Summary
- store async tasks in `bot.tasks` and handle errors via callback
- add graceful cancellation for all background tasks
- use aiohttp session timeouts
- delete only recent bot messages
- centralize FTP/API downloads in `fetch_required_files`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68715c7aa6d8832ba55a2e9a094581f9