### PR TITLE
Update /top_total limit

### DIFF
--- a/commands/top_total.py
+++ b/commands/top_total.py
@@ -12,32 +12,38 @@ async def _fetch_top_total(
     pool: Pool,
     *,
     table_name: str = "player_total_time",
-    limit: int = 50,
-) -> list[tuple[str, int]]:
-    """Fetch players with the highest total time."""
+    limit: int = 30,
+) -> tuple[list[tuple[str, int]], int]:
+    """Fetch top players and total count."""
     try:
         rows = await pool.fetch(
             f"SELECT player_name, total_hours FROM {table_name} "
             "ORDER BY total_hours DESC, player_name LIMIT $1",
             limit,
         )
+        total = await pool.fetchval(f"SELECT COUNT(*) FROM {table_name}")
     except Exception as e:
         log_debug(f"[DB] Error fetching total top: {e}")
         raise
 
-    return [(r["player_name"], int(r["total_hours"])) for r in rows]
+    return (
+        [(r["player_name"], int(r["total_hours"])) for r in rows],
+        int(total or 0),
+    )
 
 
 async def _handle_command(
     interaction: discord.Interaction,
     *,
     table_name: str = "player_total_time",
-    limit: int = 50,
+    limit: int = 30,
 ) -> None:
     await interaction.response.defer()
     pool: Pool = interaction.client.db_pool
     try:
-        rows = await _fetch_top_total(pool, table_name=table_name, limit=limit)
+        rows, total = await _fetch_top_total(
+            pool, table_name=table_name, limit=limit
+        )
     except Exception:
         await interaction.followup.send(
             "Ошибка при получении топа.", ephemeral=True
@@ -52,6 +58,9 @@ async def _handle_command(
     for idx, (name, hours) in enumerate(rows, start=1):
         lines.append(f"{idx}. {name} — {hours} ч")
 
+    if total > limit:
+        lines.append(f"Показаны только первые {limit} игроков из {total}.")
+
     await interaction.followup.send("\n".join(lines))
 
 
@@ -59,7 +68,7 @@ def setup(
     tree: app_commands.CommandTree,
     *,
     table_name: str = "player_total_time",
-    limit: int = 50,
+    limit: int = 30,
 ) -> None:
     @tree.command(name="top_total", description="Топ игроков по общему времени")
     async def top_total_command(interaction: discord.Interaction) -> None:


### PR DESCRIPTION
## Summary
- limit `/top_total` command to at most 30 players
- show notice if there are more players in database

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687160148660832b893f146cb3d1461c