### PR TITLE
Optimize heavy SQL queries

### DIFF
--- a/utils/weekly_archiver.py
+++ b/utils/weekly_archiver.py
@@ -81,12 +81,15 @@ async def archive_weekly_top(
                     """
                 )
                 await conn.execute(f"TRUNCATE TABLE {table_name}")
-                for name, hours in rows:
-                    await conn.execute(
-                        f"INSERT INTO {table_name} (player_name, hours) VALUES ($1, $2)",
-                        name,
-                        hours,
-                    )
+                await conn.executemany(
+                    f"""
+                    INSERT INTO {table_name} (player_name, hours)
+                    VALUES ($1, $2)
+                    ON CONFLICT (player_name) DO UPDATE
+                    SET hours = EXCLUDED.hours
+                    """,
+                    rows,
+                )
         log_debug("[ARCHIVER] Топ игроков сохранён")
     except Exception as e:
         log_debug(f"[DB] Error writing weekly top: {e}")


### PR DESCRIPTION
## Summary
- limit history in total time query
- batch insert total time updates
- batch weekly top archive writes
- batch history logging with conflict handling
- unify queries when fetching total leaderboard

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687166e85148832ba7323c0daf344274