### PR TITLE
Unify wait time handling

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -168,7 +168,7 @@ async def save_online_history_task(bot: discord.Client) -> None:
                         except Exception as db_e:
                             log_debug(f"[DB] Ошибка записи игрока: {db_e}")
 
-                    await asyncio.sleep(60)
+                    wait_seconds = 60
                 else:
                     wait_seconds = ((15 - (minute % 15)) * 60) - now.second
                     if wait_seconds <= 0:


### PR DESCRIPTION
## Summary
- store the 60 second delay in a variable
- use a single `await asyncio.sleep(wait_seconds)` after the `if/else`

## Testing
- `python -m py_compile bot/updater.py`

------
https://chatgpt.com/codex/tasks/task_e_6871ea19f2a0832b83b0ff537a57d085