### PR TITLE
Fix parse_all type hint

### DIFF
--- a/bot/parsers.py
+++ b/bot/parsers.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-from typing import Tuple, Optional, Dict
+from typing import Tuple, Optional, Dict, Any
 
 from utils.logger import log_debug
 
@@ -149,7 +149,7 @@ def parse_all(
     farms_xml: Optional[str] = None,
     dedicated_server_stats: Optional[str] = None,
     farm_id: str = '1'
-) -> Dict[str, Optional[int]]:
+) -> Dict[str, Any]:
     """Собирает все данные из разных источников и возвращает единую структуру."""
     try:
         server_name, map_name, slots_used, slots_max, _ = parse_server_stats(server_stats)


### PR DESCRIPTION
## Summary
- broaden return type for `parse_all`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871f2c8f630832b9c38fedd92082907