### PR TITLE
Fix aiohttp typings setup

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+python_version = 3.10
+install_types = true
+non_interactive = true
+
+[mypy-aiohttp.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ asyncpg>=0.27
 discord.py>=2.3
 matplotlib>=3.5
 python-dotenv>=0.21
-types-aiohttp
 types-python-dotenv


### PR DESCRIPTION
## Summary
- remove nonexistent `types-aiohttp` stub package from requirements
- add `mypy.ini` with config for `aiohttp` imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f72af1cc832baada067c50e488ee