### PR TITLE
Remove invalid stub dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ asyncpg>=0.27
 discord.py>=2.3
 matplotlib>=3.5
 python-dotenv>=0.21
-types-python-dotenv


### PR DESCRIPTION
## Summary
- drop non-existent `types-python-dotenv` from requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f9e8b52c832b91ba04b5f9fd76c1