### PR TITLE
Fix asyncpg dependency handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.10-slim
+
+# Install system dependencies for PostgreSQL
+RUN apt-get update && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Reinstall asyncpg to avoid corrupted installation
+RUN pip uninstall asyncpg -y && pip install asyncpg
+
+COPY . .
+
+CMD ["python", "main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aioftp>=0.21
 aiohttp>=3.8
-asyncpg>=0.27
+asyncpg>=0.27.0
 discord.py>=2.3
 matplotlib>=3.5
 python-dotenv>=0.21


### PR DESCRIPTION
## Summary
- update asyncpg to `>=0.27.0`
- provide Dockerfile with reinstall step for asyncpg and system libpq-dev

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871fbec7684832b9151455b31ef07e2