### PR TITLE
Fix monthly and daily graph queries

### DIFF
--- a/utils/online_daily_graph.py
+++ b/utils/online_daily_graph.py
@@ -19,11 +19,11 @@ async def fetch_daily_online_counts(db_pool) -> List[int]:
     try:
         rows = await db_pool.fetch(
             """
-            SELECT EXTRACT(HOUR FROM check_time) AS hour,
+            SELECT COALESCE(hour, EXTRACT(HOUR FROM check_time)) AS hour,
                    COUNT(DISTINCT player_name) AS count
             FROM player_online_history
             WHERE check_time >= $1
-            GROUP BY EXTRACT(HOUR FROM check_time)
+            GROUP BY COALESCE(hour, EXTRACT(HOUR FROM check_time))
             ORDER BY hour
             """,
             start,
@@ -31,6 +31,8 @@ async def fetch_daily_online_counts(db_pool) -> List[int]:
     except Exception as e:
         log_debug(f"[DB] Error fetching online day data: {e}")
         raise
+
+    log_debug(f"[GRAPH] Данные за сутки: {rows}")
 
     counts = [0] * 24
     for row in rows:

--- a/utils/online_month_graph.py
+++ b/utils/online_month_graph.py
@@ -49,17 +49,19 @@ async def generate_online_month_graph(db_pool) -> Optional[str]:
     try:
         rows = await db_pool.fetch(
             f"""
-            SELECT DATE(check_time) AS day,
+            SELECT COALESCE(date, DATE(check_time)) AS day,
                    COUNT(DISTINCT player_name) AS count
             FROM player_online_history
             WHERE check_time >= NOW() - INTERVAL '{ONLINE_MONTH_DAYS} days'
-            GROUP BY day
+            GROUP BY COALESCE(date, DATE(check_time))
             ORDER BY day
             """
         )
     except Exception as e:
         log_debug(f"[DB] Error fetching online month data: {e}")
         raise
+
+    log_debug(f"[GRAPH] Месячные данные: {rows}")
 
     if not rows:
         return None


### PR DESCRIPTION
## Summary
- stabilize queries for daily/monthly online graphs
- log raw query data for debugging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68720bfb4d94832b957efe2da9742ae5