### PR TITLE
Optimize DB/FTP usage

### DIFF
--- a/ftp/fetcher.py
+++ b/ftp/fetcher.py
@@ -34,3 +34,40 @@ async def fetch_file(file_name: str) -> Optional[str]:
     except Exception as e:
         log_debug(f"[FTP] ❌ Error downloading file '{file_name}': {e}")
         return None
+
+
+async def fetch_files(*file_names: str) -> list[Optional[str]]:
+    """Download multiple files during a single FTP session."""
+    log_debug(
+        f"[FTP] Connecting to {config.ftp_host}:{config.ftp_port} as {config.ftp_user}"
+    )
+    results: list[Optional[str]] = []
+    try:
+        async with aioftp.Client.context(
+            config.ftp_host,
+            config.ftp_port,
+            user=config.ftp_user,
+            password=config.ftp_pass,
+        ) as ftp_client:
+            log_debug(f"[FTP] Entering {config.ftp_profile_dir}...")
+            await ftp_client.change_directory(config.ftp_profile_dir)
+            log_debug(f"[FTP] Entering {config.ftp_savegame_dir}...")
+            await ftp_client.change_directory(config.ftp_savegame_dir)
+
+            for fname in file_names:
+                try:
+                    log_debug(f"[FTP] Downloading file: {fname}")
+                    async with ftp_client.download_stream(fname) as stream:
+                        content = await stream.read()
+                        log_debug(
+                            f"[FTP] File {fname} downloaded. Size: {len(content)} bytes"
+                        )
+                        results.append(content.decode("utf-8"))
+                except Exception as e:
+                    log_debug(f"[FTP] ❌ Error downloading file '{fname}': {e}")
+                    results.append(None)
+    except Exception as e:
+        log_debug(f"[FTP] ❌ Error connecting to FTP: {e}")
+        results = [None for _ in file_names]
+
+    return results

--- a/schema.sql
+++ b/schema.sql
@@ -8,12 +8,16 @@ CREATE TABLE IF NOT EXISTS player_online_history (
 );
 
 CREATE INDEX IF NOT EXISTS idx_online_name_date_hour ON player_online_history (player_name, date, hour);
+-- Ускоряем выборки по времени
+CREATE INDEX IF NOT EXISTS idx_online_check_time ON player_online_history (check_time);
 
 CREATE TABLE IF NOT EXISTS player_total_time (
     player_name TEXT PRIMARY KEY,
     total_hours INTEGER NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );
+-- Индекс для сортировки по общему времени
+CREATE INDEX IF NOT EXISTS idx_total_hours ON player_total_time (total_hours DESC);
 
 CREATE TABLE IF NOT EXISTS weekly_top_last (
     player_name TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add missing indexes for frequent queries
- cache dedicated-server-stats.xml and use single FTP session
- edit Discord messages instead of deleting and resending
- simplify history slice check and remove unused API polling task

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68721f375f30832b8baff5443881f53d