### PR TITLE
Add in-game time line to embed

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -26,6 +26,8 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
     vehicles_owned = data.get("vehicles_owned")
     last_month_profit = data.get("last_month_profit")
     players_online = data.get("players_online", [])
+    day_time_val = data.get("day_time")
+    time_scale_val = data.get("time_scale")
 
     slots_str = (
         f"{slots_used if slots_used is not None else '—'} /"
@@ -51,11 +53,26 @@ def build_embed(data: Dict[str, Any]) -> discord.Embed:
     )
     vehicles_str = f"{vehicles_owned if vehicles_owned is not None else '—'}"
 
+    time_str = "—"
+    if isinstance(day_time_val, int):
+        minutes_total = day_time_val // 60000
+        hours = (minutes_total // 60) % 24
+        minutes = minutes_total % 60
+        time_str = f"{hours:02d}:{minutes:02d}"
+
+    scale_str = "—"
+    if time_scale_val is not None:
+        try:
+            scale_str = f"×{round(float(time_scale_val))}"
+        except (ValueError, TypeError):
+            pass
+
     # Текст embed'a формируем единой строкой
     lines = [
         data.get("server_status", "—"),
         f"🧷 **Сервер:** {server_name}",
         f"🗺️ **Карта:** {map_name}",
+        f"🕒 Время в игре: {time_str} ({scale_str})",
         f"💰 **Деньги фермы:** {money_str}",
         f"🌾 **Поля во владении:** {fields_str}",
         f"🚜 **Техника:** {vehicles_str} единиц",

--- a/bot/fetchers.py
+++ b/bot/fetchers.py
@@ -79,15 +79,31 @@ async def fetch_dedicated_server_stats_cached(
 
 async def fetch_required_files(
     session: aiohttp.ClientSession,
-) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> Tuple[
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+    Optional[str],
+]:
     """Fetch all files required for building server stats."""
     log_debug("[API] Получаем dedicated-server-stats.xml")
     stats_xml = await fetch_dedicated_server_stats_cached(session)
     log_debug("[API] Получаем vehicles")
     vehicles_xml = await fetch_api_file(session, "vehicles")
+    log_debug("[API] Получаем careerSavegame из API")
+    career_api_xml = await fetch_api_file(session, "careerSavegame")
 
     career_ftp, farmland_ftp, farms_ftp = await fetch_files(
         "careerSavegame.xml", "farmland.xml", "farms.xml"
     )
 
-    return stats_xml, vehicles_xml, career_ftp, farmland_ftp, farms_ftp
+    return (
+        stats_xml,
+        vehicles_xml,
+        career_api_xml,
+        career_ftp,
+        farmland_ftp,
+        farms_ftp,
+    )


### PR DESCRIPTION
## Summary
- fetch career savegame from API
- parse dayTime and timeScale from XML data
- show game time line in Discord embed
- skip updates if less than 15 minutes of game time have passed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872a84ad768832b84874640fedaf5fa