### PR TITLE
Update play time display

### DIFF
--- a/bot/discord_ui.py
+++ b/bot/discord_ui.py
@@ -20,10 +20,7 @@ def format_play_time(value: Any) -> str | None:
     except (ValueError, TypeError):
         return None
     hours = total_minutes // 60
-    minutes = total_minutes % 60
-    if hours >= 1:
-        return f"⏱ Общее время игры: {hours} ч. {minutes} мин."
-    return f"⏱ Общее время игры: {minutes} мин."
+    return f"🕒 Общее время игры: {hours} ч."
 
 
 def build_embed(data: Dict[str, Any]) -> discord.Embed:


### PR DESCRIPTION
## Summary
- drop minutes from total play time
- switch icon for play time to `🕒`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6872b85f4e54832b9dd7473b9fee3a95